### PR TITLE
SCRUM-175: Admin user management redesign with JIT activity loading

### DIFF
--- a/TreeGuardiansExpo/app/(protected)/admin/manageUsers.tsx
+++ b/TreeGuardiansExpo/app/(protected)/admin/manageUsers.tsx
@@ -5,6 +5,7 @@ import {
 	ActivityIndicator,
 	ScrollView,
 	TextInput,
+	TouchableOpacity,
 } from 'react-native';
 import { router } from 'expo-router';
 import { AppContainer } from '@/components/base/AppContainer';
@@ -20,15 +21,60 @@ import {
 	deleteManagedUser,
 	fetchManagedUsers,
 	fetchTreeOptions,
+	fetchUserActivity,
 	ManagedUser,
 	removeGuardianFromTree,
 	updateUserRole,
+	UserActivityItem,
 } from '@/lib/adminApi';
 
 type TreeSummary = {
 	id: number;
 	species?: string | null;
 };
+
+type ExpandState = {
+	activityLoading: boolean;
+	activityLoaded: boolean;
+	activity: UserActivityItem[] | null;
+	activityError: string | null;
+	rolePickerOpen: boolean;
+	treePickerOpen: boolean;
+	treeSearch: string;
+};
+
+const ROLE_OPTIONS: Array<{ value: ManagedUser['role']; label: string }> = [
+	{ value: 'registered_user', label: 'User' },
+	{ value: 'guardian', label: 'Guardian' },
+	{ value: 'admin', label: 'Admin' },
+];
+
+function roleLabel(role: ManagedUser['role']): string {
+	switch (role) {
+		case 'admin': return 'Admin';
+		case 'guardian': return 'Guardian';
+		default: return 'User';
+	}
+}
+
+function formatActivityDate(dateStr: string | null): string {
+	if (!dateStr) return '';
+	const d = new Date(dateStr);
+	if (isNaN(d.getTime())) return '';
+	return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+function makeDefaultExpandState(): ExpandState {
+	return {
+		activityLoading: false,
+		activityLoaded: false,
+		activity: null,
+		activityError: null,
+		rolePickerOpen: false,
+		treePickerOpen: false,
+		treeSearch: '',
+	};
+}
 
 export default function ManageUsersPage() {
 	const { user: sessionUser, isLoading } = useSessionUser();
@@ -39,29 +85,23 @@ export default function ManageUsersPage() {
 	const [loadingData, setLoadingData] = useState(true);
 	const [busyKey, setBusyKey] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
-	const [treeInputByUser, setTreeInputByUser] = useState<Record<number, string>>({});
 	const [searchQuery, setSearchQuery] = useState('');
 	const [statusMessage, setStatusMessage] = useState<StatusMessage | null>(null);
+	const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
+	const [expandData, setExpandData] = useState<Record<number, ExpandState>>({});
 
 	const showStatusMessage = (title: string, message: string, variant: 'success' | 'error') => {
-		setStatusMessage({
-			title,
-			message,
-			variant,
-			createdAt: Date.now(),
-		});
+		setStatusMessage({ title, message, variant, createdAt: Date.now() });
 	};
 
 	const loadData = useCallback(async () => {
 		try {
 			setLoadingData(true);
 			setError(null);
-
 			const [nextUsers, nextTrees] = await Promise.all([
 				fetchManagedUsers(),
 				fetchTreeOptions(),
 			]);
-
 			setUsers(nextUsers);
 			setTrees(nextTrees);
 		} catch (err) {
@@ -79,82 +119,84 @@ export default function ManageUsersPage() {
 
 	const filteredUsers = useMemo(() => {
 		const query = searchQuery.trim().toLowerCase();
-
-		if (!query) {
-			return users;
-		}
-
-		return users.filter((managedUser) => {
-			const usernameMatch = managedUser.username.toLowerCase().includes(query);
-			const emailMatch = (managedUser.email ?? '').toLowerCase().includes(query);
-			const roleMatch = managedUser.role.toLowerCase().includes(query);
-			const idMatch = String(managedUser.id).includes(query);
-
-			return usernameMatch || emailMatch || roleMatch || idMatch;
-		});
+		if (!query) return users;
+		return users.filter((u) =>
+			u.username.toLowerCase().includes(query) ||
+			(u.email ?? '').toLowerCase().includes(query) ||
+			u.role.toLowerCase().includes(query) ||
+			String(u.id).includes(query)
+		);
 	}, [users, searchQuery]);
 
-	const treeNameMap = useMemo(() => {
-		return new Map(
-			trees.map((tree) => [
-				tree.id,
-				tree.species ? `${tree.species} (#${tree.id})` : `Tree #${tree.id}`,
-			])
-		);
-	}, [trees]);
+	const treeNameMap = useMemo(
+		() => new Map(trees.map((t) => [t.id, t.species ? `${t.species} (#${t.id})` : `Tree #${t.id}`])),
+		[trees]
+	);
 
-	const setUserTreeInput = (userId: number, value: string) => {
-		setTreeInputByUser((current) => ({
-			...current,
-			[userId]: value,
+	const getExpand = (userId: number): ExpandState =>
+		expandData[userId] ?? makeDefaultExpandState();
+
+	const setExpand = (userId: number, patch: Partial<ExpandState>) => {
+		setExpandData((prev) => ({
+			...prev,
+			[userId]: { ...(prev[userId] ?? makeDefaultExpandState()), ...patch },
 		}));
 	};
 
-	const handleRoleChange = async (
-		targetUser: ManagedUser,
-		role: 'registered_user' | 'guardian' | 'admin'
-	) => {
+	const loadActivity = useCallback(async (userId: number) => {
+		setExpand(userId, { activityLoading: true, activityError: null });
 		try {
-			setBusyKey(`role-${targetUser.id}-${role}`);
+			const activity = await fetchUserActivity(userId);
+			setExpand(userId, { activity, activityLoaded: true });
+		} catch (err) {
+			setExpand(userId, {
+				activityError: err instanceof Error ? err.message : 'Failed to load activity.',
+				activityLoaded: true,
+			});
+		} finally {
+			setExpand(userId, { activityLoading: false });
+		}
+	}, []);
+
+	const toggleExpand = (userId: number) => {
+		setExpandedIds((prev) => {
+			const next = new Set(prev);
+			if (next.has(userId)) {
+				next.delete(userId);
+			} else {
+				next.add(userId);
+				const state = expandData[userId] ?? makeDefaultExpandState();
+				if (!state.activityLoaded && !state.activityLoading) {
+					void loadActivity(userId);
+				}
+			}
+			return next;
+		});
+	};
+
+	const handleRoleChange = async (targetUser: ManagedUser, role: ManagedUser['role']) => {
+		try {
+			setBusyKey(`role-${targetUser.id}`);
+			setExpand(targetUser.id, { rolePickerOpen: false });
 			await updateUserRole(targetUser.id, role);
 			await loadData();
+			showStatusMessage('Role updated', `${targetUser.username} is now ${roleLabel(role)}.`, 'success');
 		} catch (err) {
-			showStatusMessage(
-				'Role update failed',
-				err instanceof Error ? err.message : 'Unknown error.',
-				'error'
-			);
+			showStatusMessage('Role update failed', err instanceof Error ? err.message : 'Unknown error.', 'error');
 		} finally {
 			setBusyKey(null);
 		}
 	};
 
-	const handleAssignTree = async (targetUser: ManagedUser) => {
-		const rawTreeId = treeInputByUser[targetUser.id]?.trim();
-
-		if (!rawTreeId) {
-			showStatusMessage('Missing tree id', 'Enter a tree ID first.', 'error');
-			return;
-		}
-
-		const treeId = Number(rawTreeId);
-
-		if (!Number.isInteger(treeId) || treeId <= 0) {
-			showStatusMessage('Invalid tree id', 'Tree ID must be a positive number.', 'error');
-			return;
-		}
-
+	const handleAssignTree = async (targetUser: ManagedUser, treeId: number) => {
 		try {
 			setBusyKey(`assign-${targetUser.id}-${treeId}`);
+			setExpand(targetUser.id, { treePickerOpen: false, treeSearch: '' });
 			await assignGuardianToTree(targetUser.id, treeId);
-			setUserTreeInput(targetUser.id, '');
 			await loadData();
+			showStatusMessage('Tree assigned', `${treeNameMap.get(treeId) ?? `Tree #${treeId}`} assigned to ${targetUser.username}.`, 'success');
 		} catch (err) {
-			showStatusMessage(
-				'Assignment failed',
-				err instanceof Error ? err.message : 'Unknown error.',
-				'error'
-			);
+			showStatusMessage('Assignment failed', err instanceof Error ? err.message : 'Unknown error.', 'error');
 		} finally {
 			setBusyKey(null);
 		}
@@ -166,36 +208,29 @@ export default function ManageUsersPage() {
 			await removeGuardianFromTree(targetUser.id, treeId);
 			await loadData();
 		} catch (err) {
-			showStatusMessage(
-				'Removal failed',
-				err instanceof Error ? err.message : 'Unknown error.',
-				'error'
-			);
+			showStatusMessage('Removal failed', err instanceof Error ? err.message : 'Unknown error.', 'error');
 		} finally {
 			setBusyKey(null);
 		}
 	};
 
-	const handleDeleteUser = async (targetUser: ManagedUser) => {
+	const handleDeleteUser = (targetUser: ManagedUser) => {
 		if (sessionUser?.id === targetUser.id) {
 			showStatusMessage('Action blocked', 'You cannot delete your own admin account.', 'error');
 			return;
 		}
-
 		showConfirm(
 			'Delete User',
-			`Are you sure you want to delete ${targetUser.username}? This cannot be undone.`,
+			`Are you sure you want to permanently delete ${targetUser.username}? This cannot be undone.`,
 			async () => {
 				try {
 					setBusyKey(`delete-${targetUser.id}`);
 					await deleteManagedUser(targetUser.id);
+					setExpandedIds((prev) => { const next = new Set(prev); next.delete(targetUser.id); return next; });
 					await loadData();
+					showStatusMessage('User deleted', `${targetUser.username} has been removed.`, 'success');
 				} catch (err) {
-					showStatusMessage(
-						'Delete failed',
-						err instanceof Error ? err.message : 'Unknown error.',
-						'error'
-					);
+					showStatusMessage('Delete failed', err instanceof Error ? err.message : 'Unknown error.', 'error');
 				} finally {
 					setBusyKey(null);
 				}
@@ -218,22 +253,13 @@ export default function ManageUsersPage() {
 		return (
 			<AppContainer>
 				<View style={styles.topBar}>
-					<NavigationButton onPress={() => router.push('/mainPage')}>
-						Back to Map
-					</NavigationButton>
+					<NavigationButton onPress={() => router.push('/mainPage')}>Back to Map</NavigationButton>
 				</View>
-
 				<AppText variant="title" style={styles.title}>Access Restricted</AppText>
 				<AppText style={styles.subtitle}>
-					Your account role ({sessionUser?.role ?? 'guest'}) does not have permission to manage
-					users.
+					Your account role ({sessionUser?.role ?? 'guest'}) does not have permission to manage users.
 				</AppText>
-
-				<AppButton
-					title="Return to Map"
-					variant="secondary"
-					onPress={() => router.push('/mainPage')}
-				/>
+				<AppButton title="Return to Map" variant="secondary" onPress={() => router.push('/mainPage')} />
 			</AppContainer>
 		);
 	}
@@ -243,9 +269,7 @@ export default function ManageUsersPage() {
 			<StatusMessageBox status={statusMessage} onClose={() => setStatusMessage(null)} />
 
 			<View style={styles.topBar}>
-				<NavigationButton onPress={() => router.push('/mainPage')}>
-					Back to Map
-				</NavigationButton>
+				<NavigationButton onPress={() => router.push('/mainPage')}>Back to Map</NavigationButton>
 			</View>
 
 			<AppText variant="title" style={styles.title}>Manage Users</AppText>
@@ -279,105 +303,230 @@ export default function ManageUsersPage() {
 						</View>
 					) : null}
 
-					{filteredUsers.length === 0 ? (
+					{filteredUsers.length === 0 && !error ? (
 						<View style={styles.emptyState}>
 							<AppText style={styles.userMeta}>No users matched your search.</AppText>
 						</View>
 					) : null}
 
-					{filteredUsers.map((managedUser) => (
-						<View key={managedUser.id} style={styles.userCard}>
-							<AppText style={styles.userName}>{managedUser.username}</AppText>
-							<AppText style={styles.userMeta}>User ID: {managedUser.id}</AppText>
-							<AppText style={styles.userMeta}>Role: {managedUser.role}</AppText>
-							{managedUser.email ? (
-								<AppText style={styles.userMeta}>Email: {managedUser.email}</AppText>
-							) : null}
+					{filteredUsers.map((managedUser) => {
+						const isExpanded = expandedIds.has(managedUser.id);
+						const expand = getExpand(managedUser.id);
+						const isBusy = busyKey !== null;
+						const badgeStyle = roleBadgeColors(managedUser.role);
 
-							<View style={styles.roleActions}>
-								<AppButton
-									title="Make User"
-									variant="secondary"
-									onPress={() => void handleRoleChange(managedUser, 'registered_user')}
-									disabled={busyKey !== null || managedUser.role === 'registered_user'}
-								/>
-								<AppButton
-									title="Make Guardian"
-									variant="secondary"
-									onPress={() => void handleRoleChange(managedUser, 'guardian')}
-									disabled={busyKey !== null || managedUser.role === 'guardian'}
-								/>
-								<AppButton
-									title="Make Admin"
-									variant="secondary"
-									onPress={() => void handleRoleChange(managedUser, 'admin')}
-									disabled={busyKey !== null || managedUser.role === 'admin'}
-								/>
-							</View>
-
-							<View style={styles.guardianSection}>
-								<AppText style={styles.sectionLabel}>Guardian tree assignments</AppText>
-
-								{managedUser.guardianTreeIds.length === 0 ? (
-									<AppText style={styles.userMeta}>No assigned trees.</AppText>
-								) : (
-									<View style={styles.tagWrap}>
-										{managedUser.guardianTreeIds.map((treeId) => (
-											<View key={`${managedUser.id}-${treeId}`} style={styles.treeTag}>
-												<AppText style={styles.treeTagText}>
-													{treeNameMap.get(treeId) ?? `Tree #${treeId}`}
-												</AppText>
-												<AppButton
-													title="Remove"
-													variant="secondary"
-													onPress={() => void handleRemoveTree(managedUser, treeId)}
-													disabled={busyKey !== null}
-												/>
-											</View>
-										))}
+						return (
+							<View key={managedUser.id} style={styles.userCard}>
+								<TouchableOpacity
+									onPress={() => toggleExpand(managedUser.id)}
+									style={styles.cardHeader}
+									activeOpacity={0.75}
+								>
+									<View style={styles.cardHeaderLeft}>
+										<AppText style={styles.userName}>{managedUser.username}</AppText>
+										<AppText style={styles.userMeta}>ID #{managedUser.id}</AppText>
 									</View>
-								)}
+									<View style={styles.cardHeaderRight}>
+										<View style={[styles.roleBadge, { backgroundColor: badgeStyle.bg, borderColor: badgeStyle.border }]}>
+											<AppText style={[styles.roleBadgeText, { color: badgeStyle.text }]}>
+												{roleLabel(managedUser.role)}
+											</AppText>
+										</View>
+										<AppText style={styles.chevron}>{isExpanded ? '▲' : '▼'}</AppText>
+									</View>
+								</TouchableOpacity>
 
-								<TextInput
-									value={treeInputByUser[managedUser.id] ?? ''}
-									onChangeText={(value) => setUserTreeInput(managedUser.id, value)}
-									placeholder="Enter tree ID"
-									keyboardType="number-pad"
-									style={styles.input}
-									placeholderTextColor={Theme.Colours.textMuted}
-								/>
+								{managedUser.email ? (
+									<AppText style={styles.userMetaEmail}>{managedUser.email}</AppText>
+								) : null}
 
-								<AppButton
-									title="Assign Tree"
-									variant="primary"
-									onPress={() => void handleAssignTree(managedUser)}
-									disabled={busyKey !== null}
-								/>
+								{isExpanded ? (
+									<View style={styles.expandedContent}>
+										<View style={styles.divider} />
+
+										{/* Role */}
+										<AppText style={styles.sectionLabel}>Role</AppText>
+										<TouchableOpacity
+											onPress={() => setExpand(managedUser.id, { rolePickerOpen: !expand.rolePickerOpen, treePickerOpen: false })}
+											style={styles.pickerTrigger}
+											disabled={isBusy}
+										>
+											<AppText style={styles.pickerTriggerText}>{roleLabel(managedUser.role)}</AppText>
+											<AppText style={styles.pickerChevron}>{expand.rolePickerOpen ? '▲' : '▼'}</AppText>
+										</TouchableOpacity>
+
+										{expand.rolePickerOpen ? (
+											<View style={styles.pickerDropdown}>
+												{ROLE_OPTIONS.map((option) => (
+													<TouchableOpacity
+														key={option.value}
+														onPress={() => void handleRoleChange(managedUser, option.value)}
+														style={[
+															styles.pickerOption,
+															managedUser.role === option.value && styles.pickerOptionSelected,
+														]}
+														disabled={isBusy}
+													>
+														<AppText style={[
+															styles.pickerOptionText,
+															managedUser.role === option.value && styles.pickerOptionTextSelected,
+														]}>
+															{option.label}
+														</AppText>
+														{managedUser.role === option.value ? (
+															<AppText style={styles.pickerOptionCheck}>✓</AppText>
+														) : null}
+													</TouchableOpacity>
+												))}
+											</View>
+										) : null}
+
+										<View style={styles.divider} />
+
+										{/* Guardian Trees */}
+										<AppText style={styles.sectionLabel}>
+											Guardian Trees ({managedUser.guardianTreeIds.length})
+										</AppText>
+
+										{managedUser.guardianTreeIds.length === 0 ? (
+											<AppText style={styles.userMeta}>No trees assigned.</AppText>
+										) : (
+											<View style={styles.tagWrap}>
+												{managedUser.guardianTreeIds.map((treeId) => (
+													<View key={`${managedUser.id}-${treeId}`} style={styles.treeTag}>
+														<AppText style={styles.treeTagText}>
+															{treeNameMap.get(treeId) ?? `Tree #${treeId}`}
+														</AppText>
+														<TouchableOpacity
+															onPress={() => void handleRemoveTree(managedUser, treeId)}
+															style={styles.removeTreeButton}
+															disabled={isBusy}
+														>
+															<AppText style={styles.removeTreeText}>Remove</AppText>
+														</TouchableOpacity>
+													</View>
+												))}
+											</View>
+										)}
+
+										{/* Assign Tree */}
+										<AppText style={styles.assignLabel}>Assign a tree</AppText>
+										<TouchableOpacity
+											onPress={() => setExpand(managedUser.id, { treePickerOpen: !expand.treePickerOpen, rolePickerOpen: false })}
+											style={styles.pickerTrigger}
+											disabled={isBusy}
+										>
+											<AppText style={styles.pickerTriggerPlaceholder}>Select a tree...</AppText>
+											<AppText style={styles.pickerChevron}>{expand.treePickerOpen ? '▲' : '▼'}</AppText>
+										</TouchableOpacity>
+
+										{expand.treePickerOpen ? (
+											<View style={styles.treePickerPanel}>
+												<TextInput
+													value={expand.treeSearch}
+													onChangeText={(value) => setExpand(managedUser.id, { treeSearch: value })}
+													placeholder="Search trees..."
+													style={styles.treeSearchInput}
+													placeholderTextColor={Theme.Colours.textMuted}
+												/>
+												<ScrollView style={styles.treePickerScroll} nestedScrollEnabled>
+													{trees
+														.filter((t) => {
+															const q = expand.treeSearch.trim().toLowerCase();
+															if (!q) return true;
+															return (
+																String(t.id).includes(q) ||
+																(t.species ?? '').toLowerCase().includes(q)
+															);
+														})
+														.filter((t) => !managedUser.guardianTreeIds.includes(t.id))
+														.slice(0, 30)
+														.map((t) => (
+															<TouchableOpacity
+																key={t.id}
+																onPress={() => void handleAssignTree(managedUser, t.id)}
+																style={styles.treePickerOption}
+																disabled={isBusy}
+															>
+																<AppText style={styles.treePickerOptionText}>
+																	{treeNameMap.get(t.id) ?? `Tree #${t.id}`}
+																</AppText>
+															</TouchableOpacity>
+														))}
+												</ScrollView>
+											</View>
+										) : null}
+
+										<View style={styles.divider} />
+
+										{/* Activity */}
+										<AppText style={styles.sectionLabel}>Recent Activity</AppText>
+
+										{expand.activityLoading ? (
+											<View style={styles.activityLoading}>
+												<ActivityIndicator size="small" color={Theme.Colours.primary} />
+												<AppText style={styles.userMeta}>Loading activity...</AppText>
+											</View>
+										) : expand.activityError ? (
+											<AppText style={styles.activityError}>{expand.activityError}</AppText>
+										) : expand.activity && expand.activity.length > 0 ? (
+											<View style={styles.activityList}>
+												{expand.activity.map((item, idx) => (
+													<View key={idx} style={styles.activityItem}>
+														<View style={styles.activityDot} />
+														<View style={styles.activityBody}>
+															<AppText style={styles.activityLabel}>{item.label}</AppText>
+															{item.detail ? (
+																<AppText style={styles.activityDetail}>{item.detail}</AppText>
+															) : null}
+															{item.createdAt ? (
+																<AppText style={styles.activityDate}>
+																	{formatActivityDate(item.createdAt)}
+																</AppText>
+															) : null}
+														</View>
+													</View>
+												))}
+											</View>
+										) : (
+											<AppText style={styles.userMeta}>No recent activity.</AppText>
+										)}
+
+										<View style={styles.divider} />
+
+										{/* Delete */}
+										<TouchableOpacity
+											onPress={() => handleDeleteUser(managedUser)}
+											style={[
+												styles.deleteButton,
+												(isBusy || sessionUser?.id === managedUser.id) && styles.deleteButtonDisabled,
+											]}
+											disabled={isBusy || sessionUser?.id === managedUser.id}
+										>
+											<AppText style={styles.deleteButtonText}>Delete Account</AppText>
+										</TouchableOpacity>
+									</View>
+								) : null}
 							</View>
-
-							<View style={styles.deleteRow}>
-								<AppButton
-									title="Delete User"
-									variant="accent"
-									onPress={() => void handleDeleteUser(managedUser)}
-									disabled={busyKey !== null || sessionUser?.id === managedUser.id}
-								/>
-							</View>
-						</View>
-					))}
+						);
+					})}
 
 					<View style={styles.actions}>
 						<AppButton title="Refresh" variant="secondary" onPress={() => void loadData()} />
-						<AppButton
-							title="Return to Map"
-							variant="secondary"
-							onPress={() => router.push('/mainPage')}
-						/>
+						<AppButton title="Return to Map" variant="secondary" onPress={() => router.push('/mainPage')} />
 					</View>
 				</ScrollView>
 			)}
 		</AppContainer>
 	);
+}
+
+function roleBadgeColors(role: ManagedUser['role']): { bg: string; text: string; border: string } {
+	switch (role) {
+		case 'admin': return { bg: '#EDF0FF', text: '#3730A3', border: '#C7D2FE' };
+		case 'guardian': return { bg: '#ECFDF5', text: '#065F46', border: '#A7F3D0' };
+		default: return { bg: '#F3F4F6', text: '#4B5563', border: '#D1D5DB' };
+	}
 }
 
 const styles = StyleSheet.create({
@@ -414,8 +563,22 @@ const styles = StyleSheet.create({
 		borderWidth: 1,
 		borderColor: '#D7E4D7',
 		backgroundColor: '#F9FCF9',
-		padding: Theme.Spacing.medium,
 		marginBottom: Theme.Spacing.medium,
+		overflow: 'hidden',
+	},
+	cardHeader: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+		padding: Theme.Spacing.medium,
+	},
+	cardHeaderLeft: {
+		flex: 1,
+		gap: 2,
+	},
+	cardHeaderRight: {
+		flexDirection: 'row',
+		alignItems: 'center',
 		gap: Theme.Spacing.small,
 	},
 	userName: {
@@ -425,42 +588,208 @@ const styles = StyleSheet.create({
 	userMeta: {
 		color: Theme.Colours.textMuted,
 	},
-	roleActions: {
+	userMetaEmail: {
+		color: Theme.Colours.textMuted,
+		paddingHorizontal: Theme.Spacing.medium,
+		paddingBottom: Theme.Spacing.small,
+	},
+	roleBadge: {
+		borderWidth: 1,
+		borderRadius: Theme.Radius.small,
+		paddingHorizontal: 8,
+		paddingVertical: 2,
+	},
+	roleBadgeText: {
+		fontSize: 12,
+		fontFamily: 'Poppins_600SemiBold',
+	},
+	chevron: {
+		color: Theme.Colours.textMuted,
+		fontSize: 12,
+	},
+	expandedContent: {
+		paddingHorizontal: Theme.Spacing.medium,
+		paddingBottom: Theme.Spacing.medium,
 		gap: Theme.Spacing.small,
 	},
-	guardianSection: {
-		marginTop: Theme.Spacing.small,
-		gap: Theme.Spacing.small,
+	divider: {
+		height: 1,
+		backgroundColor: '#D7E4D7',
+		marginVertical: Theme.Spacing.small,
 	},
 	sectionLabel: {
 		fontFamily: 'Poppins_600SemiBold',
 		color: Theme.Colours.textPrimary,
+		marginBottom: 2,
 	},
-	input: {
+	assignLabel: {
+		fontFamily: 'Poppins_600SemiBold',
+		color: Theme.Colours.textPrimary,
+		marginTop: Theme.Spacing.small,
+		marginBottom: 2,
+	},
+	pickerTrigger: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
 		borderWidth: 1,
 		borderColor: '#D7E4D7',
 		borderRadius: Theme.Radius.small,
 		backgroundColor: '#FFFFFF',
 		paddingHorizontal: Theme.Spacing.medium,
 		paddingVertical: Theme.Spacing.small,
+	},
+	pickerTriggerText: {
 		color: Theme.Colours.textPrimary,
+	},
+	pickerTriggerPlaceholder: {
+		color: Theme.Colours.textMuted,
+	},
+	pickerChevron: {
+		color: Theme.Colours.textMuted,
+		fontSize: 12,
+	},
+	pickerDropdown: {
+		borderWidth: 1,
+		borderColor: '#D7E4D7',
+		borderRadius: Theme.Radius.small,
+		backgroundColor: '#FFFFFF',
+		overflow: 'hidden',
+		marginTop: 4,
+	},
+	pickerOption: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+		paddingHorizontal: Theme.Spacing.medium,
+		paddingVertical: Theme.Spacing.small,
+		borderBottomWidth: 1,
+		borderBottomColor: '#F0F5F0',
+	},
+	pickerOptionSelected: {
+		backgroundColor: '#EDF9EE',
+	},
+	pickerOptionText: {
+		color: Theme.Colours.textPrimary,
+	},
+	pickerOptionTextSelected: {
+		color: Theme.Colours.primary,
+		fontFamily: 'Poppins_600SemiBold',
+	},
+	pickerOptionCheck: {
+		color: Theme.Colours.primary,
+		fontFamily: 'Poppins_600SemiBold',
 	},
 	tagWrap: {
 		gap: Theme.Spacing.small,
 	},
 	treeTag: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
 		borderWidth: 1,
 		borderColor: '#D7E4D7',
 		borderRadius: Theme.Radius.small,
 		backgroundColor: '#FFFFFF',
-		padding: Theme.Spacing.small,
-		gap: Theme.Spacing.small,
+		paddingHorizontal: Theme.Spacing.medium,
+		paddingVertical: 6,
 	},
 	treeTagText: {
 		color: Theme.Colours.textPrimary,
+		flex: 1,
 	},
-	deleteRow: {
+	removeTreeButton: {
+		paddingHorizontal: Theme.Spacing.small,
+		paddingVertical: 4,
+	},
+	removeTreeText: {
+		color: '#B91C1C',
+		fontFamily: 'Poppins_600SemiBold',
+		fontSize: 13,
+	},
+	treePickerPanel: {
+		borderWidth: 1,
+		borderColor: '#D7E4D7',
+		borderRadius: Theme.Radius.small,
+		backgroundColor: '#FFFFFF',
+		marginTop: 4,
+		overflow: 'hidden',
+	},
+	treeSearchInput: {
+		borderBottomWidth: 1,
+		borderBottomColor: '#D7E4D7',
+		paddingHorizontal: Theme.Spacing.medium,
+		paddingVertical: Theme.Spacing.small,
+		color: Theme.Colours.textPrimary,
+	},
+	treePickerScroll: {
+		maxHeight: 200,
+	},
+	treePickerOption: {
+		paddingHorizontal: Theme.Spacing.medium,
+		paddingVertical: Theme.Spacing.small,
+		borderBottomWidth: 1,
+		borderBottomColor: '#F0F5F0',
+	},
+	treePickerOptionText: {
+		color: Theme.Colours.textPrimary,
+	},
+	activityLoading: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: Theme.Spacing.small,
+	},
+	activityError: {
+		color: '#B91C1C',
+	},
+	activityList: {
+		gap: Theme.Spacing.small,
+	},
+	activityItem: {
+		flexDirection: 'row',
+		gap: Theme.Spacing.small,
+		alignItems: 'flex-start',
+	},
+	activityDot: {
+		width: 8,
+		height: 8,
+		borderRadius: 4,
+		backgroundColor: Theme.Colours.primary,
+		marginTop: 5,
+		flexShrink: 0,
+	},
+	activityBody: {
+		flex: 1,
+		gap: 2,
+	},
+	activityLabel: {
+		color: Theme.Colours.textPrimary,
+		fontFamily: 'Poppins_600SemiBold',
+		fontSize: 13,
+	},
+	activityDetail: {
+		color: Theme.Colours.textMuted,
+		fontSize: 12,
+	},
+	activityDate: {
+		color: Theme.Colours.textMuted,
+		fontSize: 11,
+	},
+	deleteButton: {
+		borderWidth: 1,
+		borderColor: '#FECACA',
+		borderRadius: Theme.Radius.small,
+		backgroundColor: '#FEF2F2',
+		paddingVertical: Theme.Spacing.small,
+		alignItems: 'center',
 		marginTop: Theme.Spacing.small,
+	},
+	deleteButtonDisabled: {
+		opacity: 0.5,
+	},
+	deleteButtonText: {
+		color: '#B91C1C',
+		fontFamily: 'Poppins_600SemiBold',
 	},
 	loadingRow: {
 		flex: 1,

--- a/TreeGuardiansExpo/lib/adminApi.ts
+++ b/TreeGuardiansExpo/lib/adminApi.ts
@@ -181,6 +181,55 @@ export async function removeGuardianFromTree(userId: number, treeId: number): Pr
   }
 }
 
+export type UserActivityItem = {
+  type: 'comment' | 'tree_added';
+  label: string;
+  detail: string;
+  treeId?: number;
+  createdAt: string | null;
+};
+
+export async function fetchUserActivity(userId: number): Promise<UserActivityItem[]> {
+  const response = await fetch(buildApiUrl(`admin/users/${userId}/activity`), {
+    headers: await getAuthHeaders(),
+  });
+
+  const rawBody = await response.text();
+  const parsed = safeParseJson(rawBody) as { comments?: any[]; createdTrees?: any[] } | undefined;
+
+  if (!response.ok) {
+    throw new Error(formatApiError('Failed to fetch user activity.', response, rawBody));
+  }
+
+  const items: UserActivityItem[] = [];
+
+  for (const c of parsed?.comments ?? []) {
+    items.push({
+      type: 'comment',
+      label: `Commented on Tree #${c.tree_id}`,
+      detail: c.content ? (c.content.length > 80 ? `${String(c.content).slice(0, 80)}…` : String(c.content)) : '',
+      treeId: Number(c.tree_id),
+      createdAt: c.created_at ?? null,
+    });
+  }
+
+  for (const t of parsed?.createdTrees ?? []) {
+    items.push({
+      type: 'tree_added',
+      label: `Added ${t.species ? String(t.species) : 'a tree'} (Tree #${t.tree_id})`,
+      detail: '',
+      treeId: Number(t.tree_id),
+      createdAt: t.created_at ?? null,
+    });
+  }
+
+  return items.sort((a, b) => {
+    const da = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const db = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return db - da;
+  });
+}
+
 export async function deleteManagedUser(userId: number): Promise<void> {
   const response = await fetch(buildApiUrl(`admin/users/${userId}`), {
     method: 'DELETE',

--- a/server/src/db/modules/workflows.js
+++ b/server/src/db/modules/workflows.js
@@ -456,6 +456,39 @@ function createWorkflows(ctx) {
           isAdmin,
           guardianTreeIds
         };
+      },
+
+      async getUserActivity(userId, params = {}) {
+        ensurePositiveInt("userId", userId);
+        const { limit } = normalizeListParams({ limit: params.limit ?? 10, offset: 0 });
+
+        const [recentComments, recentTrees] = await Promise.all([
+          run(
+            runtimeExecutor(),
+            `SELECT ct.comment_id, ct.tree_id, ct.content, ct.created_at
+             FROM comments_tree ct
+             INNER JOIN comments c ON c.id = ct.comment_id
+             WHERE c.user_id = ?
+             ORDER BY ct.created_at DESC
+             LIMIT ?`,
+            [userId, limit]
+          ),
+          run(
+            runtimeExecutor(),
+            `SELECT tcd.tree_id, tcd.created_at, td.tree_species AS species
+             FROM tree_creation_data tcd
+             LEFT JOIN tree_data td ON td.tree_id = tcd.tree_id
+             WHERE tcd.creator_user_id = ?
+             ORDER BY tcd.created_at DESC
+             LIMIT ?`,
+            [userId, limit]
+          ),
+        ]);
+
+        return {
+          comments: Array.isArray(recentComments) ? recentComments : [],
+          createdTrees: Array.isArray(recentTrees) ? recentTrees : [],
+        };
       }
     }
   };

--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -138,6 +138,20 @@ function createUsersRoute({ db }) {
     res.json({ success: true });
   }));
 
+  router.get("/admin/users/:userId/activity", asyncHandler(async (req, res) => {
+    const routeLog = getRouteLogger(req, { route: "admin.users.activity" });
+    await requireAdminUser({ req, db, routeLog });
+
+    const userId = Number(req.params.userId);
+
+    if (!Number.isInteger(userId) || userId <= 0) {
+      return res.status(400).json({ error: "Invalid user id." });
+    }
+
+    const activity = await db.workflows.users.getUserActivity(userId, { limit: 10 });
+    res.json(activity);
+  }));
+
   router.delete("/admin/users/:userId", asyncHandler(async (req, res) => {
     const routeLog = getRouteLogger(req, { route: "admin.users.delete" });
     const auth = await requireAdminUser({ req, db, routeLog });


### PR DESCRIPTION
Rewrites the manage users page with an accordion pattern — cards expand on tap to reveal role picker, guardian tree assignment, per-user activity feed, and a red delete button. Activity is loaded just-in-time per user rather than upfront. Adds a server-side activity endpoint and workflow, plus a searchable tree picker replacing the raw text input.