### PR TITLE
SCRUM-190: Adding Trees Boundary Fix

### DIFF
--- a/TreeGuardiansExpo/components/base/MapComponent.types.ts
+++ b/TreeGuardiansExpo/components/base/MapComponent.types.ts
@@ -123,6 +123,37 @@ export const CHARLTON_CENTER = {
   longitude: -2.0475,
 };
 
+/** Outer ring as GeoJSON order: [lng, lat] — same geometry as the highlighted map boundary */
+const CHARLTON_KINGS_RING_LNG_LAT: [number, number][] = regionOuterRing
+  .filter((coordinate) => Array.isArray(coordinate) && coordinate.length >= 2)
+  .map(([lng, lat]) => [lng, lat] as [number, number]);
+
+const isPointInPolygonLngLat = (lng: number, lat: number, ring: [number, number][]): boolean => {
+  if (ring.length < 3) {
+    return false;
+  }
+
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [xi, yi] = ring[i];
+    const [xj, yj] = ring[j];
+    if (yi === yj) {
+      continue;
+    }
+    const crossesHorizontalRay =
+      (yi > lat) !== (yj > lat) && lng < ((xj - xi) * (lat - yi)) / (yj - yi) + xi;
+    if (crossesHorizontalRay) {
+      inside = !inside;
+    }
+  }
+  return inside;
+};
+
+/** True only inside the Charlton Kings boundary polygon (matches the highlighted outline), not the padded map box */
+export const isCoordinateWithinCharltonKingsBoundary = (coordinate: MapCoordinate): boolean => {
+  return isPointInPolygonLngLat(coordinate.longitude, coordinate.latitude, CHARLTON_KINGS_RING_LNG_LAT);
+};
+
 export const isCoordinateWithinBounds = (coordinate: MapCoordinate): boolean => {
   return (
     coordinate.latitude >= BOUNDS.southWest.lat &&

--- a/TreeGuardiansExpo/hooks/useTreeMapState.ts
+++ b/TreeGuardiansExpo/hooks/useTreeMapState.ts
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import * as Location from 'expo-location';
 import { Tree, TreeDetails } from '@/objects/TreeDetails';
 import { addTreeData, fetchTrees } from '@/lib/treeApi';
-import { CHARLTON_CENTER, MapCoordinate, PlotPointer, isCoordinateWithinBounds } from '@/components/base/MapComponent.types';
+import {
+  CHARLTON_CENTER,
+  MapCoordinate,
+  PlotPointer,
+  isCoordinateWithinCharltonKingsBoundary,
+} from '@/components/base/MapComponent.types';
 import { haversineDistanceKm } from '@/utilities/geo';
 import type { StatusMessage } from '@/components/base/StatusMessageBox';
 
@@ -204,6 +209,13 @@ export function useTreeMapState() {
       return;
     }
 
+    if (!isCoordinateWithinCharltonKingsBoundary(coordinate)) {
+      setAddValidationError(
+        'That point is outside the Charlton Kings boundary. Tap inside the highlighted area on the map.'
+      );
+      return;
+    }
+
     setSelectedDraftLocation(coordinate);
     setIsSelectingManualLocation(false);
     setAddValidationError(null);
@@ -237,10 +249,17 @@ export function useTreeMapState() {
       }
 
       const location = await Location.getCurrentPositionAsync({});
-      setSelectedDraftLocation({
+      const coord: MapCoordinate = {
         latitude: location.coords.latitude,
         longitude: location.coords.longitude,
-      });
+      };
+      if (!isCoordinateWithinCharltonKingsBoundary(coord)) {
+        setAddValidationError(
+          'Your current location is outside the Charlton Kings boundary. Use “Select On Map” to pick a point inside the highlighted area.'
+        );
+        return;
+      }
+      setSelectedDraftLocation(coord);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown location error.';
       setAddValidationError(`Unable to get current location: ${message}`);
@@ -261,9 +280,9 @@ export function useTreeMapState() {
       return;
     }
 
-    if (!isCoordinateWithinBounds(selectedDraftLocation)) {
+    if (!isCoordinateWithinCharltonKingsBoundary(selectedDraftLocation)) {
       setAddValidationError(
-        'Selected location is outside the supported map bounds (Charlton Kings). Please choose a point inside the map area.'
+        'Selected location is outside the Charlton Kings boundary. Choose a point inside the highlighted area.'
       );
       return;
     }


### PR DESCRIPTION
Validate add-tree coordinates with point-in-polygon against the same GeoJSON ring used for the map outline, instead of the padded bounding box.