### PR TITLE
Update documentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,6 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/TreeGuardiansExpo" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/TreeGuardiansExpo"
     schedule:
       interval: "weekly"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,6 @@ on:
   pull_request:
 
 jobs:
-  # -----------------------------
-  # JavaScript / React Native / Expo
-  # -----------------------------
   lint-js:
     name: JS / React Native / Expo Lint
     runs-on: ubuntu-latest
@@ -41,9 +38,6 @@ jobs:
       - name: Expo doctor (optional)
         run: npx expo-doctor || true
 
-  # -----------------------------
-  # SQL Lint
-  # -----------------------------
   lint-sql:
     name: SQL Lint
     runs-on: ubuntu-latest
@@ -60,9 +54,6 @@ jobs:
       - name: Run SQLFluff
         run: sqlfluff lint . --dialect mysql
 
-  # -----------------------------
-  # PHP Lint
-  # -----------------------------
   lint-php:
     name: PHP Lint
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pre-commit.log
 logs/*.log
 !logs/.gitkeep
 .vscode/*
+*.docx

--- a/PLESK.md
+++ b/PLESK.md
@@ -1,286 +1,78 @@
-# PLESK
+# Plesk Deployment
 
-## Overview
+Plesk runs the root `app.js`, which loads `server/.env`, starts the Node backend, and serves the Expo web export when static serving is enabled.
 
-This project consists of two parts:
+## Runtime Shape
 
-* **Backend (Node.js)** → `/server`
-* **Frontend (Expo Web build)** → `/TreeGuardiansExpo/dist`
-
-Plesk is configured to:
-
-* Run the Node.js backend
-* Serve the built Expo app as static files
-
----
-
-## Directory Layout (Production)
-
-```
+```text
 /tree_guardians
-├── app.js                  # Plesk entry point
-├── server/                 # Backend
+├── app.js
+├── server/
 └── TreeGuardiansExpo/
-    └── dist/               # Built frontend (served publicly)
+    └── dist/
 ```
 
----
+`server/src/config.js` defaults to production-safe web serving when `NODE_ENV=production` and `START_EXPO=false`: Expo is not spawned, `EXPO_STATIC_ENABLED` defaults to `true`, and `EXPO_AUTO_PREPARE` defaults to `true`.
 
-## Plesk Configuration
+## Plesk Node App
 
-### Node.js Settings
+| Setting | Value |
+| --- | --- |
+| Application root | repository root |
+| Startup file | `app.js` |
+| Document root | `TreeGuardiansExpo/dist` if Plesk serves static files directly; otherwise repository root is enough for Node static serving |
 
-| Setting                  | Value                                    |
-| ------------------------ | ---------------------------------------- |
-| Application Root         | `/tree_guardians`                        |
-| Application Startup File | `app.js`                                 |
-| Document Root            | `/tree_guardians/TreeGuardiansExpo/dist` |
+The package manifests declare Node `20.20.1`. The current `plesk_deploy.sh` writes `.node-version` as `16` before installing backend dependencies, so the Plesk Node version must be checked after deployment.
 
-### Notes
+## Environment
 
-* **Application Root must contain Document Root** (Plesk requirement)
-* `app.js` should only start the backend (e.g. require `./server/server.js`)
-* Static files are served directly from `/dist`
+Create `server/.env` on the server from `server/.env.example`.
 
----
+Minimum production values:
 
-## Node Version (nodenv)
+- `NODE_ENV=production`
+- `PORT=<plesk-assigned-port-or-4000>`
+- `JWT_SECRET=<strong-secret>`
+- `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_DATABASE`
+- `FRONTEND_URL=<public-site-origin>`
+- `START_EXPO=false`
+- `EXPO_STATIC_ENABLED=true`
+- `EXPO_WEB_DIST_PATH=<absolute-path-to-TreeGuardiansExpo/dist>`
 
-Plesk uses `nodenv`, so a local Node version must be defined.
+Email verification and password reset require `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, and `SMTP_FROM`.
 
-### Set Node version
+## Deploy Script
 
-SSH into the server:
-
-```bash
-cd /tree_guardians
-nodenv local 20.0.0
-```
-
-This creates:
-
-```
-.node-version
-```
-
-### Verify
-
-```bash
-nodenv version
-node -v
-```
-
----
-
-## Git Deployment Setup
-
-In Plesk:
-
-* Enable **Git integration**
-* Set deployment action to:
+Plesk Git deployment can run:
 
 ```bash
 bash plesk_deploy.sh
 ```
 
----
+Current script behavior:
 
-## Deployment Script
+1. Writes `.node-version`.
+2. Initializes `nodenv`.
+3. Runs `npm install --omit=dev` in `server/`.
+4. Creates `server/uploads`.
+5. Touches `tmp/restart.txt`.
 
-Create `plesk_deploy.sh` in repo root:
+The script does not build Expo. With `EXPO_AUTO_PREPARE=true`, backend startup installs Expo dependencies if needed and runs `npm run export:web`.
 
-```bash
-#!/bin/bash
-set -e
+## Checks
 
-ROOT="$(pwd)"
-SERVER_DIR="$ROOT/server"
-EXPO_DIR="$ROOT/TreeGuardiansExpo"
+- `server/.env` exists and contains production DB and JWT values.
+- `TreeGuardiansExpo/dist/index.html` exists after startup or deploy.
+- `/health` returns `{ "status": "ok" }`.
+- `/db/health` returns HTTP `200` with `ready: true`.
+- Uploaded files can be written under `server/uploads`.
 
-# Initialise nodenv (required in Plesk)
-export NODENV_ROOT="$HOME/.nodenv"
-export PATH="$NODENV_ROOT/bin:$PATH"
-eval "$(nodenv init -)"
+## Common Failures
 
-echo "Node: $(node -v)"
-echo "NPM: $(npm -v)"
+`npm: command not found`: Plesk did not initialize `nodenv`; check the deploy script output.
 
-echo "=== Installing backend ==="
-cd "$SERVER_DIR"
-npm install --omit=dev
+Frontend 404: the Expo export is missing, `EXPO_WEB_DIST_PATH` is wrong, or Plesk document root points outside the app root.
 
-echo "=== Installing frontend ==="
-cd "$EXPO_DIR"
-npm install
+Email links fail: `FRONTEND_URL` is missing or does not match the public site origin.
 
-echo "=== Building Expo ==="
-npx expo export --platform web
-
-echo "=== Restarting app ==="
-mkdir -p "$ROOT/tmp"
-touch "$ROOT/tmp/restart.txt"
-
-echo "=== Deployment complete ==="
-```
-
-Make executable:
-
-```bash
-chmod +x plesk_deploy.sh
-```
-
----
-
-## Environment Variables
-
-* Configure environment variables via:
-
-  * Plesk UI (preferred), or
-  * `.env` files (if supported by your server code)
-
-Ensure:
-
-* Backend uses correct production values
-* Frontend API URLs point to deployed backend
-
----
-
-## Common Issues
-
-### 1. `npm: command not found`
-
-Cause:
-
-* nodenv not initialized
-
-Fix:
-
-* Ensure script includes:
-
-```bash
-eval "$(nodenv init -)"
-```
-
----
-
-### 2. `nodenv: no local version configured`
-
-Cause:
-
-* Missing `.node-version`
-
-Fix:
-
-```bash
-nodenv local 16.20.2
-```
-
----
-
-### 3. Expo build fails
-
-Possible causes:
-
-* Node version mismatch
-* Missing dependencies
-
-Fix:
-
-* Ensure Node 16.20.x is used
-* Run `npm install` locally and commit lockfiles if needed
-
----
-
-### 4. 404 on frontend
-
-Common causes:
-
-* `dist/` not built
-* wrong Document Root
-* SPA routing not handled
-
-Check:
-
-* `/TreeGuardiansExpo/dist/index.html` exists
-* correct Plesk Document Root
-
----
-
-## Deployment Flow
-
-1. Push to Git repository
-2. Plesk pulls changes
-3. `plesk_deploy.sh` runs:
-
-   * installs dependencies
-   * builds frontend
-   * restarts backend
-4. Site updates live
-
----
-
-## Notes
-
-* Avoid using `npm ci` unless lockfiles are committed
-* Node version must match server capabilities (glibc constraints)
-* Frontend is static; backend handles API only
-
----
-
-## Local Stack (Redesigned)
-
-The local Docker stack has been reorganized to keep Docker assets centralized and make running the full environment one command.
-
-### Docker Layout
-
-```
-docker/
-├── compose.local.yml
-├── images/
-│   ├── server.Dockerfile
-│   ├── expo.Dockerfile
-│   └── android-emulator.Dockerfile
-└── scripts/
-  ├── watch-expo-web.sh
-  └── android-emulator-entrypoint.sh
-```
-
-### One Command To Run
-
-```bash
-./scripts/local_plesk_stack.sh
-```
-
-Quiet mode (mostly Expo output in terminal):
-
-```bash
-./scripts/local_plesk_stack.sh -q
-```
-
-Stop with `Ctrl+C`.
-
-### What You See In Terminal
-
-The launcher always prints stable local URLs at startup:
-
-* `http://localhost:4000/` (backend + static web)
-* `http://localhost:8081/` (Expo dev server)
-* `http://localhost:6080/vnc.html` (Android emulator noVNC)
-
-`expo` is always attached in quiet mode so Expo QR/tunnel lines remain visible in terminal.
-
-### Logging
-
-Full logs are always streamed into per-service files in `logs/`:
-
-* `logs/mysql.log`
-* `logs/server.log`
-* `logs/expo-web-build.log`
-* `logs/expo.log`
-* `logs/android-emulator.log`
-
-### Expo/Emulator Notes
-
-* Expo tunnel mode is preconfigured with `@expo/ngrok` installed in the Expo image.
-* Android emulator image resolves Expo Go APK for SDK `54`.
-* If a container fails to boot, stack exits (no restart loop).
+Database boot fails: required `DB_*` values are missing, the database user lacks access, or `DB_ALLOW_CREATE_DATABASE=false` while the database does not exist.

--- a/README.md
+++ b/README.md
@@ -1,192 +1,35 @@
-# CT5038-DatabaseApp
-Database Application for University Module CT5038
+# TreeGuardians
 
-The Database Application is a PHP application designed to interface with existing web apps over API, where web apps can query the database through API calls.
+TreeGuardians is an Expo app and Node/MySQL backend for mapping, recording, and managing trees in the Charlton Kings boundary.
 
-## Setting up you dev environment
+## Quick Start
 
-This project uses VS Code Dev Containers to provide a standardized development environment across the entire team. This ensures everyone has the same PHP version, database servers, and tools configured identically.
-
-### Prerequisites
-
-1. **Install Docker Desktop**
-   - [Windows/Mac](https://www.docker.com/products/docker-desktop)
-   - Linux: Install Docker Engine and Docker Compose
-
-2. **Install Visual Studio Code**
-   - Download from [code.visualstudio.com](https://code.visualstudio.com/)
-
-3. **Install Dev Containers Extension**
-   - Open VS Code
-   - Press `Ctrl+Shift+X` (or `Cmd+Shift+X` on Mac)
-   - Search for "Dev Containers" by Microsoft
-   - Click Install
-
-### Quick Start
-
-1. **Clone the repository**
-   ```bash
-   git clone https://github.com/TheCharlesChristy/CT5038-DatabaseApp.git
-   cd CT5038-DatabaseApp
-   ```
-
-2. **Open in VS Code**
-   ```bash
-   code .
-   ```
-
-3. **Start the Dev Container**
-   - VS Code will prompt "Folder contains a Dev Container configuration file. Reopen folder to develop in a container"
-   - Click **"Reopen in Container"**
-   - Alternatively, press `F1` and select **"Dev Containers: Reopen in Container"**
-
-4. **Wait for the container to build**
-   - First time setup takes 5-10 minutes as it downloads and builds all services
-   - Subsequent starts are much faster (under 1 minute)
-
-5. **Verify the setup**
-   ```bash
-   php example-db-test.php
-   ```
-   You should see successful connections to MySQL, PostgreSQL, and SQLite.
-
-### What's Included
-
-The development environment includes:
-
-- **PHP 8.3** with Apache web server
-- **MySQL 8.0** database server
-- **PostgreSQL 16** database server
-- **SQLite** support (lightweight database)
-- **Composer** (PHP dependency manager)
-- **XDebug** (debugging tool configured for VS Code)
-- **Adminer** (web-based database management GUI)
-
-### Accessing Services
-
-Once the dev container is running:
-
-| Service | URL/Connection | Credentials |
-|---------|----------------|-------------|
-| Web Server | http://localhost:8080 | N/A |
-| Adminer (DB GUI) | http://localhost:8081 | See below |
-| MySQL | `localhost:3306` | user: `devuser`, password: `devpassword`, db: `devdb` |
-| PostgreSQL | `localhost:5432` | user: `postgres`, password: `postgres`, db: `devdb` |
-| SQLite | File: `/var/db/sqlite/*.db` | N/A |
-
-### Working with Databases
-
-#### Using Adminer (Recommended for Beginners)
-
-1. Open http://localhost:8081 in your browser
-2. Select your database system (MySQL or PostgreSQL)
-3. Enter the credentials from the table above
-4. Click "Login"
-
-You can now browse tables, run queries, and manage your database through the web interface.
-
-#### Using VS Code SQLTools Extension
-
-The dev container automatically configures SQLTools with connections to both MySQL and PostgreSQL:
-
-1. Click the database icon in the VS Code sidebar
-2. Expand "MySQL Dev" or "PostgreSQL Dev"
-3. Write and execute SQL queries directly in VS Code
-
-#### Connecting from PHP Code
-
-```php
-// MySQL
-$mysql = new PDO('mysql:host=mysql;dbname=devdb', 'devuser', 'devpassword');
-
-// PostgreSQL
-$postgres = new PDO('pgsql:host=postgres;dbname=devdb', 'postgres', 'postgres');
-
-// SQLite
-$sqlite = new PDO('sqlite:/var/db/sqlite/mydb.db');
-```
-
-### Debugging with XDebug
-
-1. Set a breakpoint in your PHP file (click left of line number)
-2. Press `F5` or go to Run → Start Debugging
-3. Select "Listen for XDebug"
-4. Access your PHP file through the browser
-5. VS Code will pause at your breakpoint
-
-### Troubleshooting
-
-**Container won't start:**
-- Ensure Docker Desktop is running
-- Check no other services are using ports 8080, 8081, 3306, 5432
-- Try "Dev Containers: Rebuild Container" from the command palette (`F1`)
-
-**Can't connect to database:**
-- Verify containers are running: Open terminal and run `docker ps`
-- Check container logs: `docker-compose logs mysql` or `docker-compose logs postgres`
-- Ensure you're using the correct hostname (`mysql` or `postgres`, not `localhost`) from within PHP
-
-**Permission errors:**
-- The container runs as `www-data` user
-- File permissions are automatically managed by Docker
-
-### Stopping the Environment
-
-When you close VS Code or select "Reopen Folder Locally", the containers continue running in the background. To stop them:
+Prerequisites: Docker with Compose, Linux KVM access for the Android emulator, and Node 20.20.1 for host-side package work.
 
 ```bash
-docker-compose -f .devcontainer/docker-compose.yml down
+./scripts/local_plesk_stack.sh
 ```
 
-Or through Docker Desktop → Containers → Stop
+The launcher starts MySQL, the Node backend, the Expo web exporter, the Expo dev server, and a noVNC Android emulator.
 
-## API structure
+Default local URLs:
 
-API endpoint URL's will follow best practices where they are indexed as:
+- Web app and backend: `http://localhost:4000/`
+- Expo dev server: `http://localhost:8081/`
+- Android emulator noVNC: `http://localhost:6080/vnc.html`
+
+Run backend tests:
+
+```bash
+npm test --prefix server
 ```
-<collection>/<resource>:<specific_query_information(optional)>
-```
 
-For example to get a user with a specific id:
-```
-users/42
-```
+## Further Docs
 
-Using path based lookups for API endpoints forces developers to follow best practices in both API calling/handling and database design.
-
-## Node Backend And DB Middleware
-
-The repository now includes a Node backend in `server/` that follows the canonical requirements in `ServerRequirements.md`.
-
-### DB Access Rules (Hard Constraint)
-
-- All database operations must go through the database middleware endpoint surface in `server/src/db/index.js`.
-- Only `server/src/db/**` is allowed to import SQL client libraries.
-- Raw SQL usage (`.query(`) is blocked outside middleware by the runtime DB lock and covered by backend tests.
-
-### Endpoint Groups
-
-`users`, `userPasswords`, `admins`, `userSessions`, `trees`, `treeCreationData`, `treeData`, `guardians`, `photos`, `treePhotos`, `comments`, `commentPhotos`, `commentsTree`, `commentReplies`, `wildlifeObservations`, `diseaseObservations`, `seenObservations`, and `workflows`.
-
-### Adding New Endpoints
-
-1. Add input validation in `server/src/db/validation.js`.
-2. Add or extend a named endpoint inside `server/src/db/index.js`.
-3. Use prepared statements only; do not export raw pool/connection/query access.
-4. Use middleware transactions for multi-table operations.
-5. Add tests in `server/test/` and run backend checks.
-
-### Containerized Server Run/Test
-
-Use `docker-compose.server.yml` to run the Node backend with MySQL and to execute backend tests inside the server image.
-
-- Run the local development stack: `./scripts/start_local_server.sh`
-- Run the same stack directly with Compose: `docker compose -f docker-compose.server.yml up --build server android-emulator`
-- Run lock + unit + integration tests in container: `docker compose -f docker-compose.server.yml --profile test up --build --abort-on-container-exit --exit-code-from server-test server-test`
-
-The local development flow is intentionally one command. `./scripts/start_local_server.sh` starts MySQL, the Node server, Expo, and the Android emulator container together. The server container watches `server/src/**` and restarts automatically, Expo watches `TreeGuardiansExpo/**`, `http://localhost:4000/` proxies to the Expo dev server, and the Android emulator is available through noVNC at `http://localhost:6080/vnc.html`. Stop the whole stack with `Ctrl+C`. Runtime logs are written to `logs/mysql.log`, `logs/server.log`, `logs/android-emulator.log`, and `logs/server-test.log`.
-
-Convenience scripts are available in `scripts/`:
-
-- `./scripts/test.sh` runs containerized backend tests.
-- `./scripts/run_all_checks.sh` runs repo-wide checks used by pre-commit.
+- Local Docker stack: [docs/LOCAL_SETUP.md](docs/LOCAL_SETUP.md)
+- Backend API and configuration: [server/README.md](server/README.md)
+- Expo app: [TreeGuardiansExpo/README.md](TreeGuardiansExpo/README.md)
+- Plesk deployment: [PLESK.md](PLESK.md)
+- Expo components: [TreeGuardiansExpo/components/README.md](TreeGuardiansExpo/components/README.md)
+- Style tokens: [TreeGuardiansExpo/styles/README.md](TreeGuardiansExpo/styles/README.md)
+- Tree species dataset: [TreeGuardiansExpo/docs/tree-species-dataset.md](TreeGuardiansExpo/docs/tree-species-dataset.md)

--- a/TreeGuardiansExpo/README.md
+++ b/TreeGuardiansExpo/README.md
@@ -1,0 +1,53 @@
+# Expo App
+
+TreeGuardiansExpo is the Expo Router frontend for mapping, adding, filtering, and managing Charlton Kings tree records.
+
+## Run
+
+```bash
+npm install
+npm start
+```
+
+Useful scripts:
+
+| Script | Effect |
+| --- | --- |
+| `npm run web` | Starts Expo for web development. |
+| `npm run android` | Opens the app in an Android target. |
+| `npm run ios` | Opens the app in an iOS target. |
+| `npm run export:web` | Writes the static web build to `dist/`. |
+| `npm run lint` | Runs Expo lint checks. |
+| `npm run species:update` | Regenerates the tree species dataset. |
+
+## App Structure
+
+| Path | Responsibility |
+| --- | --- |
+| `app/` | Expo Router screens and route groups. |
+| `app/(protected)/` | Screens that require a stored access token. |
+| `components/base/` | Shared UI primitives and feature panels. |
+| `components/map/` | Map overlays, markers, and filter panels. |
+| `config/api.ts` | API origin and endpoint helpers. |
+| `lib/` | Backend API clients and data transforms. |
+| `objects/` | Shared app data types. |
+| `styles/` | Theme, layout helpers, and design tokens. |
+| `utilities/` | Auth storage, alerts, phone formatting, and geo helpers. |
+
+## Environment
+
+Expo reads public variables at bundle time.
+
+| Option | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `EXPO_PUBLIC_API_BASE_URL` | URL or path | current web origin, or native fallback `http://localhost:4000/api` | Sets the full API base; `/api` is appended when missing. |
+| `EXPO_PUBLIC_API_ORIGIN` | URL | current web origin, or native fallback `http://localhost:4000` | Sets the backend origin when `EXPO_PUBLIC_API_BASE_URL` is unset. |
+| `EXPO_PUBLIC_WEB_ORIGIN` | URL | resolved API origin | Sets the public web origin used in tree QR links. |
+
+On native Expo dev builds, localhost API values are rewritten to the Expo host machine so a device or emulator can reach the backend.
+
+## Further Docs
+
+- Components: [components/README.md](components/README.md)
+- Style tokens: [styles/README.md](styles/README.md)
+- Tree species dataset: [docs/tree-species-dataset.md](docs/tree-species-dataset.md)

--- a/TreeGuardiansExpo/app/(protected)/admin/analytics.tsx
+++ b/TreeGuardiansExpo/app/(protected)/admin/analytics.tsx
@@ -18,8 +18,6 @@ import {
 	UserAnalyticsResponse,
 } from '@/lib/adminApi';
 
-// ─── Shared activity line chart ─────────────────────────────────────────────
-
 type ActivityChartPoint = { day: string; label: string; value: number };
 type TimeSeries = { label: string; colour: string; data: ActivityChartPoint[] };
 
@@ -170,8 +168,6 @@ function TimeSeriesLineChart({
 	);
 }
 
-// ─── Contributor list ────────────────────────────────────────────────────────
-
 function ContributorList({
 	items,
 	label,
@@ -209,8 +205,6 @@ function ContributorList({
 		</View>
 	);
 }
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function formatImpactValue(value: number, unit: string): string {
 	if (value === 0) return `0 ${unit}`;
@@ -253,8 +247,6 @@ function lastNDaysLabels(data: { day: string; count: number }[], n: number): Act
 
 	return result;
 }
-
-// ─── Page ────────────────────────────────────────────────────────────────────
 
 export default function AnalyticsPage() {
 	const { user, isLoading } = useSessionUser();
@@ -327,7 +319,6 @@ export default function AnalyticsPage() {
 			<FaviconHead title="Analytics | TreeGuardians" />
 			<AppContainer>
 				<ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scroll}>
-					{/* Header island */}
 					<View style={styles.headerIsland}>
 						<View style={styles.topBar}>
 							<NavigationButton onPress={() => router.push('/mainPage')} color="#FFFFFF">
@@ -351,7 +342,6 @@ export default function AnalyticsPage() {
 						</View>
 					) : (
 						<>
-							{/* ── Key Stats ─────────────────────────────────────────── */}
 							{overview ? (
 								<View style={styles.section}>
 									<AppText style={styles.sectionTitle}>Key Statistics</AppText>
@@ -368,9 +358,8 @@ export default function AnalyticsPage() {
 								</View>
 							) : null}
 
-						{/* ── Activity Trend ────────────────────────────────────── */}
 						<View style={styles.section}>
-							<AppText style={styles.sectionTitle}>Activity — last 14 days</AppText>
+							<AppText style={styles.sectionTitle}>Activity - last 14 days</AppText>
 
 							<View style={[styles.glassCard, styles.chartCard]}>
 								<TimeSeriesLineChart
@@ -393,7 +382,6 @@ export default function AnalyticsPage() {
 							</View>
 						</View>
 
-						{/* ── User Analytics ────────────────────────────────────── */}
 						{userAnalytics ? (
 							<View style={styles.section}>
 								<AppText style={styles.sectionTitle}>User Analytics</AppText>
@@ -416,7 +404,6 @@ export default function AnalyticsPage() {
 							</View>
 						) : null}
 
-						{/* ── Environmental Impact ──────────────────────────────── */}
 						{overview ? (
 							<View style={styles.section}>
 								<AppText style={styles.sectionTitle}>Environmental Impact</AppText>
@@ -462,7 +449,6 @@ const styles = StyleSheet.create({
 		paddingHorizontal: Theme.Spacing.medium,
 	},
 
-	// Header island — floating glass
 	headerIsland: {
 		backgroundColor: 'rgba(18, 72, 32, 0.88)',
 		borderRadius: Theme.Radius.medium,
@@ -506,7 +492,6 @@ const styles = StyleSheet.create({
 		gap: Theme.Spacing.small,
 	},
 
-	// Section layout
 	section: {
 		marginBottom: Theme.Spacing.large,
 	},
@@ -517,7 +502,6 @@ const styles = StyleSheet.create({
 		marginBottom: Theme.Spacing.small,
 	},
 
-	// Stat row
 	statRow: {
 		flexDirection: 'row',
 		flexWrap: 'wrap',
@@ -549,7 +533,6 @@ const styles = StyleSheet.create({
 		fontSize: 13,
 	},
 
-	// Glass card
 	glassCard: {
 		backgroundColor: 'rgba(255, 255, 255, 0.88)',
 		borderRadius: Theme.Radius.medium,
@@ -570,7 +553,6 @@ const styles = StyleSheet.create({
 		marginBottom: 4,
 	},
 
-	// Activity line chart
 	chartCard: {
 		height: 260,
 		padding: 0,
@@ -627,7 +609,6 @@ const styles = StyleSheet.create({
 		fontStyle: 'italic',
 	},
 
-	// Contributors
 	contributorRow: {
 		flexDirection: 'row',
 		alignItems: 'center',
@@ -669,7 +650,6 @@ const styles = StyleSheet.create({
 		flexShrink: 0,
 	},
 
-	// Impact grid
 	impactGrid: {
 		flexDirection: 'row',
 		flexWrap: 'wrap',
@@ -706,7 +686,6 @@ const styles = StyleSheet.create({
 		textAlign: 'center',
 	},
 
-	// Error
 	errorCard: {
 		borderWidth: 1,
 		borderColor: '#FECACA',

--- a/TreeGuardiansExpo/app/(protected)/admin/manageUsers.tsx
+++ b/TreeGuardiansExpo/app/(protected)/admin/manageUsers.tsx
@@ -359,7 +359,6 @@ export default function ManageUsersPage() {
 										<View style={styles.expandedContent}>
 										<View style={styles.divider} />
 
-										{/* Role */}
 										<AppText style={styles.sectionLabel}>Role</AppText>
 										<TouchableOpacity
 											onPress={() => setExpand(managedUser.id, { rolePickerOpen: !expand.rolePickerOpen, treePickerOpen: false })}
@@ -398,7 +397,6 @@ export default function ManageUsersPage() {
 
 										<View style={styles.divider} />
 
-										{/* Guardian Trees */}
 										<AppText style={styles.sectionLabel}>
 											Guardian Trees ({managedUser.guardianTreeIds.length})
 										</AppText>
@@ -424,7 +422,6 @@ export default function ManageUsersPage() {
 											</View>
 										)}
 
-										{/* Assign Tree */}
 										<AppText style={styles.assignLabel}>Assign a tree</AppText>
 										<TouchableOpacity
 											onPress={() => setExpand(managedUser.id, { treePickerOpen: !expand.treePickerOpen, rolePickerOpen: false })}
@@ -480,7 +477,6 @@ export default function ManageUsersPage() {
 
 										<View style={styles.divider} />
 
-										{/* Activity */}
 										<AppText style={styles.sectionLabel}>Recent Activity</AppText>
 
 										{expand.activityLoading ? (
@@ -515,7 +511,6 @@ export default function ManageUsersPage() {
 
 										<View style={styles.divider} />
 
-										{/* Delete */}
 										<TouchableOpacity
 											onPress={() => handleDeleteUser(managedUser)}
 											style={[

--- a/TreeGuardiansExpo/app/(protected)/myProfile.tsx
+++ b/TreeGuardiansExpo/app/(protected)/myProfile.tsx
@@ -325,7 +325,6 @@ export default function MyProfilePage() {
 			>
 				<View style={styles.inner}>
 
-					{/* Hero overview card */}
 					<View style={styles.heroCard}>
 						<View style={styles.avatarCircle}>
 							<AppText style={styles.avatarLetter}>{avatarLetter}</AppText>
@@ -384,7 +383,6 @@ export default function MyProfilePage() {
 						<AppText style={styles.userId}>ID #{currentUser.id}</AppText>
 					</View>
 
-					{/* Username card */}
 					<View style={styles.card}>
 						<AppText style={styles.cardTitle}>Username</AppText>
 						{!isEditingUsername ? (
@@ -437,7 +435,6 @@ export default function MyProfilePage() {
 						)}
 					</View>
 
-					{/* Email card */}
 					<View style={styles.card}>
 						<AppText style={styles.cardTitle}>Email</AppText>
 						{!isEditingEmail ? (
@@ -491,7 +488,6 @@ export default function MyProfilePage() {
 						)}
 					</View>
 
-					{/* Password card */}
 					<View style={styles.card}>
 						<AppText style={styles.cardTitle}>Password</AppText>
 						{!isChangingPassword ? (
@@ -567,7 +563,6 @@ export default function MyProfilePage() {
 						)}
 					</View>
 
-					{/* Account deletion card */}
 					<View style={styles.card}>
 						<AppText style={styles.cardTitle}>Account Deletion</AppText>
 						<AppText style={styles.deleteDescription}>
@@ -781,7 +776,6 @@ const styles = StyleSheet.create({
 		opacity: 0.55,
 	},
 
-	/* Action cards */
 	card: {
 		...GLASS_CARD,
 		padding: 18,
@@ -864,7 +858,6 @@ const styles = StyleSheet.create({
 		resendButton: {
 		marginTop: Theme.Spacing.small,
 	},
-	/* Account deletion */
 	deleteDescription: {
 		fontSize: 13,
 		color: Theme.Colours.textMuted,
@@ -882,7 +875,6 @@ const styles = StyleSheet.create({
 		color: '#B42318',
 	},
 
-	/* Modal */
 	modalOverlay: {
 		flex: 1,
 		backgroundColor: 'rgba(0, 0, 0, 0.55)',

--- a/TreeGuardiansExpo/app/(protected)/myTrees.tsx
+++ b/TreeGuardiansExpo/app/(protected)/myTrees.tsx
@@ -5,10 +5,7 @@ import { FaviconHead } from '@/components/base/FaviconHead';
 import { AppText } from '@/components/base/AppText';
 import { Theme } from '@/styles/theme';
 
-/**
- * My Trees is shown as a map overlay on mainPage. This route remains for
- * bookmarks and deep links; it forwards to the map with the overlay open.
- */
+/** Preserves /myTrees deep links by opening the My Trees map overlay. */
 export default function MyTreesRedirect() {
   useEffect(() => {
     router.replace({ pathname: '/mainPage', params: { openMyTrees: '1' } });

--- a/TreeGuardiansExpo/app/_layout.tsx
+++ b/TreeGuardiansExpo/app/_layout.tsx
@@ -67,9 +67,7 @@ export default function Layout() {
     document.head.appendChild(style);
   }, []);
 
-  // On web, fonts load via CSS so we never block the render — doing so causes
-  // a hydration mismatch (#418) because the static export pre-renders with
-  // fonts resolved but the browser's first render sees fontsLoaded=false.
+  // Web fonts load through CSS; blocking render here causes static-export hydration mismatches.
   if (!fontsLoaded && Platform.OS !== 'web') return null;
 
   return (

--- a/TreeGuardiansExpo/app/dbTestBench.tsx
+++ b/TreeGuardiansExpo/app/dbTestBench.tsx
@@ -570,7 +570,6 @@ const EXPLICIT_SCHEMAS: Record<string, EndpointSchema> = {
   },
 };
 
-// Helper to avoid circular reference in object literal for workflows.auth.createSession.
 function EXPLICIT_SCHEMAS_PLACEHOLDER(): FormField[] {
   return [
     field('userId', 'User ID', 'number', 0, 'userId', { required: true }),

--- a/TreeGuardiansExpo/app/forgot-password.tsx
+++ b/TreeGuardiansExpo/app/forgot-password.tsx
@@ -63,7 +63,7 @@ export default function ForgotPasswordScreen() {
 
     } catch (error) {
       const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
-      setStatus({ title: 'Connection Error', message: `Network or client error — ${message}`, variant: 'error', createdAt: Date.now() });
+      setStatus({ title: 'Connection Error', message: `Network or client error - ${message}`, variant: 'error', createdAt: Date.now() });
     } finally {
       setLoading(false);
     }

--- a/TreeGuardiansExpo/app/registration.tsx
+++ b/TreeGuardiansExpo/app/registration.tsx
@@ -127,7 +127,7 @@ export default function CreateAccount() {
         ? `${error.name}: ${error.message}`
         : String(error);
       console.error('Registration error:', error);
-      setStatus({ title: 'Connection Error', message: `Network or client error — ${message}`, variant: 'error', createdAt: Date.now() });
+      setStatus({ title: 'Connection Error', message: `Network or client error - ${message}`, variant: 'error', createdAt: Date.now() });
     } finally {
       setLoading(false);
     }

--- a/TreeGuardiansExpo/app/reset-password.tsx
+++ b/TreeGuardiansExpo/app/reset-password.tsx
@@ -86,7 +86,7 @@ export default function ResetPasswordScreen() {
       const msg =
         err instanceof Error ? `${err.name}: ${err.message}` : String(err);
 
-      setMessage(`Network error — ${msg}`);
+      setMessage(`Network error - ${msg}`);
       setError(true);
     } finally {
       setLoading(false);
@@ -106,7 +106,6 @@ export default function ResetPasswordScreen() {
         <View style={[styles.formColumn, !isMobileLayout && styles.formColumnCentered]}>
           <View style={[styles.formCard, isMobileLayout && styles.formCardMobile]}>
 
-            {/* Back link */}
             <View style={styles.topRow}>
               <Pressable onPress={() => router.push('/login')} style={styles.backLink}>
                 <AppText variant="caption" style={styles.backLinkText}>
@@ -115,12 +114,10 @@ export default function ResetPasswordScreen() {
               </Pressable>
             </View>
 
-            {/* Title */}
             <AppText variant="title" style={[styles.title, isMobileLayout && styles.titleMobile]}>
               Set a new password
             </AppText>
 
-            {/* Subtitle */}
             <AppText variant="body" style={styles.subtitle}>
               Enter your new password below.
             </AppText>
@@ -171,7 +168,6 @@ export default function ResetPasswordScreen() {
                 buttonStyle={styles.submitButtonInner}
               />
 
-              {/* Inline message */}
               {!!message && (
                 <View style={styles.messageBox}>
                   <AppText
@@ -186,7 +182,6 @@ export default function ResetPasswordScreen() {
                 </View>
               )}
 
-              {/* Back to login button */}
               {success && (
                 <AppButton
                   title="Back to Login"

--- a/TreeGuardiansExpo/app/themePreview.tsx
+++ b/TreeGuardiansExpo/app/themePreview.tsx
@@ -19,13 +19,10 @@ export default function ThemePreview() {
       <Stack.Screen options={{ title: 'Theme Preview | TreeGuardians' }} />
       <FaviconHead title="Theme Preview | TreeGuardians" />
       <AppContainer style={styles.container} scrollable>
-      {/* Top Left Back */}
       <NavigationButton onPress={() => router.back()} />
       
-      {/* TITLE */}
       <AppText variant="title">TreeGuardians Design System</AppText>
 
-      {/* COLORS */}
       <Section title="Colours">
         {Object.entries(Theme.Colours).map(([key, value]) => (
           <View key={key} style={styles.colorRow}>
@@ -35,7 +32,6 @@ export default function ThemePreview() {
         ))}
       </Section>
 
-      {/* TYPOGRAPHY */}
       <Section title="Typography">
         <AppText style={{
             ...Theme.Typography.title,
@@ -58,7 +54,6 @@ export default function ThemePreview() {
         </AppText>
       </Section>
 
-      {/* SPACING */}
       <Section title="Spacing">
         {Object.entries(Theme.Spacing).map(([key, value]) => (
           <View key={key} style={{ marginBottom: 10 }}>
@@ -74,7 +69,6 @@ export default function ThemePreview() {
         ))}
       </Section>
 
-      {/* BUTTONS */}
       <Section title="Buttons">
         <AppButton title="Accent Button" variant="accent" onPress={() => {}} />
         <View style={{ height: 10 }} />
@@ -85,7 +79,6 @@ export default function ThemePreview() {
         <AppButton title="Outline Button" variant="outline" onPress={() => {}} />
       </Section>
 
-      {/* INPUT */}
       <Section title="Inputs">
         <AppInput placeholder="Example Input" />
       </Section>
@@ -93,8 +86,6 @@ export default function ThemePreview() {
     </>
   );
 }
-
-/* ---------------- Section Component ---------------- */
 
 const Section = ({ title, children }: SectionProps) => (
   <View style={styles.section}>
@@ -106,8 +97,6 @@ const Section = ({ title, children }: SectionProps) => (
     </View>
   </View>
 );
-
-/* ---------------- Styles ---------------- */
 
 const styles = StyleSheet.create({
   container: {

--- a/TreeGuardiansExpo/app/verify-email.tsx
+++ b/TreeGuardiansExpo/app/verify-email.tsx
@@ -66,7 +66,6 @@ export default function VerifyEmailScreen() {
         <View style={[styles.formColumn, !isMobileLayout && styles.formColumnCentered]}>
           <View style={[styles.formCard, isMobileLayout && styles.formCardMobile]}>
 
-            {/* Back link */}
             <View style={styles.topRow}>
               <Pressable onPress={() => router.push('/login')} style={styles.backLink}>
                 <AppText variant="caption" style={styles.backLinkText}>
@@ -75,17 +74,14 @@ export default function VerifyEmailScreen() {
               </Pressable>
             </View>
 
-            {/* Title */}
             <AppText variant="title" style={[styles.title, isMobileLayout && styles.titleMobile]}>
               Email Verification
             </AppText>
 
-            {/* Subtitle */}
             <AppText variant="body" style={styles.subtitle}>
               {loading ? 'Please wait while we verify your email.' : 'Verification result:'}
             </AppText>
 
-            {/* Inline status */}
             <View style={styles.messageBox}>
               <AppText
                 variant="body"
@@ -98,7 +94,6 @@ export default function VerifyEmailScreen() {
               </AppText>
             </View>
 
-            {/* Button instead of auto redirect */}
             {!loading && (
               <AppButton
                 title="Back to Login"

--- a/TreeGuardiansExpo/components/README.md
+++ b/TreeGuardiansExpo/components/README.md
@@ -1,7 +1,29 @@
-# Navigation button can be customized like such
+# Components
 
-<NavigationButton onPress={() => navigation.navigate('/theme')}>
-  <AppText style={{ fontWeight: 'bold' }}>
-    Go To Theme
-  </AppText>
-</NavigationButton>
+`components/base` contains cross-platform UI primitives and feature panels shared by screens.
+
+`components/map` contains map overlays, marker rendering, dashboard panels, and filter/search controls.
+
+`components/auth` contains route helpers for authentication-aware navigation.
+
+Use `AppText`, `AppButton`, `AppInput`, `AppContainer`, and `AppTouchableOpacity` before raw React Native primitives when building app UI.
+
+## Key Components
+
+| Component | Purpose |
+| --- | --- |
+| `MapComponent` | Platform switch for native and web map implementations. |
+| `TreeDashboard` | Full tree detail, activity, photo, edit, QR, and admin actions panel. |
+| `AddTreeDashboard` | Collects tree details before device or manual placement. |
+| `TreeHealthSelect` | Shared health picker for add/edit and search filters. |
+| `TreeSpeciesSelect` | Species picker backed by the generated dataset. |
+| `StatusMessageBox` | Animated success/error message with optional countdown and copy action. |
+| `CircularCountdown` | SVG countdown ring used by timed status flows. |
+
+## Component Contracts
+
+`MapComponent` accepts `plottedTrees`, `selectedLocation`, `isPlotting`, `onPress`, `onTreeClick`, `renderTreeIcon`, `onViewportCenterChange`, and `onPlotPointerMove`.
+
+`TreeHealthSelect` accepts the full health range by default; pass `TREE_HEALTH_FORM_OPTIONS` for new tree submissions.
+
+`StatusMessageBox` renders `StatusMessage | null`, auto-dismisses success messages after 4 seconds, and shows a copy action for errors by default.

--- a/TreeGuardiansExpo/components/base/AddTreeDashboard.tsx
+++ b/TreeGuardiansExpo/components/base/AddTreeDashboard.tsx
@@ -131,7 +131,6 @@ export default function PlotDashboard({
   const validate = () => {
     let valid = true;
 
-    // Species validation
     if (!species.trim()) {
       setSpeciesError('Please select a tree species.');
       valid = false;
@@ -581,25 +580,25 @@ export default function PlotDashboard({
             <View style={styles.estimateBox}>
               <AppText style={styles.estimateTitle}>Estimated Environmental Impact</AppText>
               <AppText style={styles.estimateItem}>
-                Avoided Runoff: {estimatedStats.avoidedRunoff ?? '—'} m³
+                Avoided Runoff: {estimatedStats.avoidedRunoff ?? '-'} m³
               </AppText>
               <AppText style={styles.estimateItem}>
-                CO₂ Stored: {estimatedStats.carbonDioxideStored ?? '—'} kg
+                CO₂ Stored: {estimatedStats.carbonDioxideStored ?? '-'} kg
               </AppText>
               <AppText style={styles.estimateItem}>
-                CO₂ Removed: {estimatedStats.carbonDioxideRemoved ?? '—'} kg
+                CO₂ Removed: {estimatedStats.carbonDioxideRemoved ?? '-'} kg
               </AppText>
               <AppText style={styles.estimateItem}>
-                Water Intercepted: {estimatedStats.waterIntercepted ?? '—'} m³
+                Water Intercepted: {estimatedStats.waterIntercepted ?? '-'} m³
               </AppText>
               <AppText style={styles.estimateItem}>
-                Air Quality Gain: {estimatedStats.airQualityImprovement ?? '—'} g/year
+                Air Quality Gain: {estimatedStats.airQualityImprovement ?? '-'} g/year
               </AppText>
               <AppText style={styles.estimateItem}>
-                Leaf Area: {estimatedStats.leafArea ?? '—'} m²
+                Leaf Area: {estimatedStats.leafArea ?? '-'} m²
               </AppText>
               <AppText style={styles.estimateItem}>
-                Evapotranspiration: {estimatedStats.evapotranspiration ?? '—'} m³
+                Evapotranspiration: {estimatedStats.evapotranspiration ?? '-'} m³
               </AppText>
             </View>
           </View>

--- a/TreeGuardiansExpo/components/base/CircularCountdown.tsx
+++ b/TreeGuardiansExpo/components/base/CircularCountdown.tsx
@@ -3,25 +3,25 @@ import { StyleSheet, View, Text } from 'react-native';
 import Svg, { Circle } from 'react-native-svg';
 
 interface CircularCountdownProps {
-  /** Total duration in seconds */
+  /** Countdown duration in seconds. */
   duration: number;
-  /** Diameter of the circle in px */
+  /** Circle diameter in pixels. */
   size?: number;
-  /** Stroke width in px */
+  /** Ring stroke width in pixels. */
   strokeWidth?: number;
-  /** Colour of the countdown ring */
+  /** Active ring colour. */
   color?: string;
-  /** Colour of the background track */
+  /** Background track colour. */
   trackColor?: string;
-  /** When false, hides the numeric label in the center */
+  /** Hides the centre number when false. */
   showLabel?: boolean;
-  /** When true, only the background track is shown */
+  /** Shows only the background track when true. */
   trackOnly?: boolean;
-  /** Called when the countdown reaches zero */
+  /** Called once when progress reaches zero. */
   onComplete?: () => void;
 }
 
-const FRAME_MS = 1000 / 60; // ~60 fps
+const FRAME_MS = 1000 / 60;
 
 export function CircularCountdown({
   duration,
@@ -36,7 +36,7 @@ export function CircularCountdown({
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
 
-  const [progress, setProgress] = useState(1); // 1 = full, 0 = empty
+  const [progress, setProgress] = useState(1);
   const startTime = useRef(Date.now());
   const completed = useRef(false);
 

--- a/TreeGuardiansExpo/components/base/MapComponent.types.ts
+++ b/TreeGuardiansExpo/components/base/MapComponent.types.ts
@@ -124,7 +124,7 @@ export const CHARLTON_CENTER = {
   longitude: -2.0475,
 };
 
-/** Outer ring as GeoJSON order: [lng, lat] — same geometry as the highlighted map boundary */
+/** Charlton Kings boundary ring in GeoJSON [lng, lat] order. */
 const CHARLTON_KINGS_RING_LNG_LAT: [number, number][] = regionOuterRing
   .filter((coordinate) => Array.isArray(coordinate) && coordinate.length >= 2)
   .map(([lng, lat]) => [lng, lat] as [number, number]);
@@ -150,7 +150,7 @@ const isPointInPolygonLngLat = (lng: number, lat: number, ring: [number, number]
   return inside;
 };
 
-/** True only inside the Charlton Kings boundary polygon (matches the highlighted outline), not the padded map box */
+/** Returns true only inside the Charlton Kings boundary, not the padded map box. */
 export const isCoordinateWithinCharltonKingsBoundary = (coordinate: MapCoordinate): boolean => {
   return isPointInPolygonLngLat(coordinate.longitude, coordinate.latitude, CHARLTON_KINGS_RING_LNG_LAT);
 };

--- a/TreeGuardiansExpo/components/base/MapComponent.web.tsx
+++ b/TreeGuardiansExpo/components/base/MapComponent.web.tsx
@@ -14,7 +14,6 @@ import {
 } from './MapComponent.types';
 
 const isWithinRegion = (lat: number, lng: number): boolean => {
-  // Ray casting algorithm
   let inside = false;
   const ring = REGION_RING_LEAFLET;
 

--- a/TreeGuardiansExpo/components/base/PasswordStrengthIndicator.tsx
+++ b/TreeGuardiansExpo/components/base/PasswordStrengthIndicator.tsx
@@ -7,7 +7,7 @@ type Strength = 'weak' | 'fair' | 'good' | 'strong';
 interface StrengthResult {
   level: Strength;
   label: string;
-  score: number;          // 0–4 filled bars
+  score: number;
   color: string;
 }
 
@@ -23,7 +23,6 @@ export function getPasswordStrength(password: string): StrengthResult {
   if (/\d/.test(password)) score++;
   if (/[^A-Za-z0-9]/.test(password)) score++;
 
-  // Map raw score (0-5) to 4-bar scale
   if (score <= 1) return { level: 'weak',   label: 'Weak',   score: 1, color: '#B3261E' };
   if (score === 2) return { level: 'fair',   label: 'Fair',   score: 2, color: '#F9A825' };
   if (score === 3) return { level: 'good',   label: 'Good',   score: 3, color: '#66BB6A' };

--- a/TreeGuardiansExpo/components/base/StatusMessageBox.tsx
+++ b/TreeGuardiansExpo/components/base/StatusMessageBox.tsx
@@ -20,12 +20,12 @@ export type StatusMessage = {
 type StatusMessageBoxProps = {
   status: StatusMessage | null;
   onClose: () => void;
-  /** Seconds before auto-redirect on success (shows countdown). Omit to disable. */
+  /** Seconds shown in the success countdown. */
   redirectDuration?: number;
   countdownLabel?: string;
   closeLabel?: string;
   showCopyButton?: boolean;
-  /** Override the default top position (16px). Use to push below a nav bar. */
+  /** Top offset in pixels. */
   topOffset?: number;
 };
 

--- a/TreeGuardiansExpo/components/base/TreeDashboard.tsx
+++ b/TreeGuardiansExpo/components/base/TreeDashboard.tsx
@@ -2175,25 +2175,25 @@ export default function TreeDetailsDashboard({
                 <View style={styles.editEstimateBox}>
                   <AppText style={styles.editEstimateTitle}>Estimated Environmental Impact</AppText>
                   <AppText style={styles.editEstimateItem}>
-                    Avoided Runoff: {editEstimatedStats.avoidedRunoff ?? '—'} m³
+                    Avoided Runoff: {editEstimatedStats.avoidedRunoff ?? '-'} m³
                   </AppText>
                   <AppText style={styles.editEstimateItem}>
-                    CO₂ Stored: {editEstimatedStats.carbonDioxideStored ?? '—'} kg
+                    CO₂ Stored: {editEstimatedStats.carbonDioxideStored ?? '-'} kg
                   </AppText>
                   <AppText style={styles.editEstimateItem}>
-                    CO₂ Removed: {editEstimatedStats.carbonDioxideRemoved ?? '—'} kg
+                    CO₂ Removed: {editEstimatedStats.carbonDioxideRemoved ?? '-'} kg
                   </AppText>
                   <AppText style={styles.editEstimateItem}>
-                    Water Intercepted: {editEstimatedStats.waterIntercepted ?? '—'} m³
+                    Water Intercepted: {editEstimatedStats.waterIntercepted ?? '-'} m³
                   </AppText>
                   <AppText style={styles.editEstimateItem}>
-                    Air Quality Gain: {editEstimatedStats.airQualityImprovement ?? '—'} g/year
+                    Air Quality Gain: {editEstimatedStats.airQualityImprovement ?? '-'} g/year
                   </AppText>
                   <AppText style={styles.editEstimateItem}>
-                    Leaf Area: {editEstimatedStats.leafArea ?? '—'} m²
+                    Leaf Area: {editEstimatedStats.leafArea ?? '-'} m²
                   </AppText>
                   <AppText style={styles.editEstimateItem}>
-                    Evapotranspiration: {editEstimatedStats.evapotranspiration ?? '—'} m³
+                    Evapotranspiration: {editEstimatedStats.evapotranspiration ?? '-'} m³
                   </AppText>
                 </View>
               </View>

--- a/TreeGuardiansExpo/components/base/TreeHealthSelect.tsx
+++ b/TreeGuardiansExpo/components/base/TreeHealthSelect.tsx
@@ -18,7 +18,7 @@ export type SelectOption<T extends string> = {
   textColor: string;
 };
 
-/** Good / OK / Bad only - use when adding a tree (see `AddTreeDashboard`). */
+/** Good, OK, and Bad options for new tree submissions. */
 export const TREE_HEALTH_FORM_OPTIONS: SelectOption<TreeHealth>[] = [
   {
     value: 'good',
@@ -49,7 +49,7 @@ export const TREE_HEALTH_FORM_OPTIONS: SelectOption<TreeHealth>[] = [
   },
 ];
 
-/** Full tree health range - use when displaying or editing existing tree details. */
+/** Full health range for existing tree details. */
 export const TREE_HEALTH_OPTIONS: SelectOption<TreeHealth>[] = [
   {
     value: 'excellent',
@@ -116,7 +116,7 @@ type BaseProps<T extends string> = {
   options: SelectOption<T>[];
   prefixLabel?: string;
   compact?: boolean;
-  /** When current `value` is not in `options`, use this for trigger styling (e.g. legacy API health). */
+  /** Supplies trigger styling when value is absent from options. */
   getFallbackMeta?: (value: T) => SelectOption<T> | undefined;
 };
 
@@ -124,7 +124,7 @@ type TreeHealthSelectProps = {
   value?: TreeHealth;
   onChange: (value: TreeHealth) => void;
   compact?: boolean;
-  /** Defaults to full list; use `TREE_HEALTH_FORM_OPTIONS` when adding a tree (Good / OK / Bad only). */
+  /** Defaults to full range; pass `TREE_HEALTH_FORM_OPTIONS` for new tree submissions. */
   options?: SelectOption<TreeHealth>[];
 };
 

--- a/TreeGuardiansExpo/components/map/DashboardPanel.tsx
+++ b/TreeGuardiansExpo/components/map/DashboardPanel.tsx
@@ -298,7 +298,6 @@ export function DashboardPanel({
                       <AppText style={styles.weatherErrorText}>{weatherError}</AppText>
                     ) : weatherData ? (
                       <>
-                        {/* Current conditions hero */}
                         <View style={styles.weatherHero}>
                           <AppText style={styles.weatherEmoji}>{wmoEmoji(weatherData.weatherCode)}</AppText>
                           <AppText style={styles.weatherTempBig}>{weatherData.temperature}°C</AppText>
@@ -316,7 +315,6 @@ export function DashboardPanel({
                           </View>
                         </View>
 
-                        {/* Multi-day forecast */}
                         {weatherData.forecast.length > 0 ? (
                           <>
                             <AppText style={styles.forecastHeading}>4-Day Forecast</AppText>
@@ -423,7 +421,6 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
 
-  /* Weather */
   weatherLoader: {
     marginVertical: 32,
   },
@@ -565,7 +562,6 @@ const styles = StyleSheet.create({
     fontWeight: '700',
   },
 
-  /* Activity */
   activityCard: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -618,7 +614,6 @@ const styles = StyleSheet.create({
     marginVertical: 10,
   },
 
-  /* Dashboard layout */
   dashboardWrap: {
     position: 'absolute',
     left: 0,

--- a/TreeGuardiansExpo/components/map/MyTreesOverlayPanel.tsx
+++ b/TreeGuardiansExpo/components/map/MyTreesOverlayPanel.tsx
@@ -113,7 +113,7 @@ export function MyTreesOverlayPanel({
                   <View style={styles.rowBody}>
                     <View style={styles.rowTitleRow}>
                       <AppText style={styles.rowTitle} numberOfLines={1}>
-                        {tree.species ? `${tree.species} · ` : ''}Tree #{tree.id ?? '—'}
+                        {tree.species ? `${tree.species} · ` : ''}Tree #{tree.id ?? '-'}
                       </AppText>
                       <View
                         style={[

--- a/TreeGuardiansExpo/config/api.ts
+++ b/TreeGuardiansExpo/config/api.ts
@@ -79,6 +79,7 @@ function rewriteLocalhostForNative(value: string): string {
   });
 }
 
+/** Returns the absolute API base URL, always ending in `/api`. */
 export function resolveApiBaseUrl(): string {
   const windowOrigin = getWindowOrigin();
   if (windowOrigin) {
@@ -120,10 +121,12 @@ export function resolveApiBaseUrl(): string {
   return `${rewriteLocalhostForNative(DEFAULT_NATIVE_API_ORIGIN)}/api`;
 }
 
+/** Returns the backend origin without the `/api` suffix. */
 export function resolveApiOrigin(): string {
   return normalizeOrigin(resolveApiBaseUrl());
 }
 
+/** Builds an absolute API URL from an endpoint path. */
 export function buildApiUrl(path: string): string {
   const cleanPath = String(path || "").replace(/^\/+/, "");
   const base = resolveApiBaseUrl();

--- a/TreeGuardiansExpo/docs/tree-species-dataset.md
+++ b/TreeGuardiansExpo/docs/tree-species-dataset.md
@@ -1,53 +1,36 @@
-# Tree Species Dataset Maintenance
+# Tree Species Dataset
 
-This project bundles a local species dataset used by the Add Tree species selector.
+The Add Tree species selector reads `assets/data/treeSpeciesDataset.json`.
 
-## Source
+## Generate
 
-- Primary source: OpenTreeMap species API (`/instance/{instance}/species`)
-- Fallback source: OpenTreeMap `species.csv` export format
-
-The generated file is:
-
-- `assets/data/treeSpeciesDataset.json`
-
-Each species entry includes:
-
-- `label` (display value)
-- `commonName`
-- `scientificName`
-- `otmCode`
-- `usdaCode` (nullable placeholder)
-- `iTreeCode` (nullable placeholder)
-
-`Other / Unknown` is always appended as a fallback option.
-
-## Updating the dataset
-
-From `TreeGuardiansExpo`:
+Run from `TreeGuardiansExpo/`:
 
 ```bash
 npm run species:update
 ```
 
-If your chosen OpenTreeMap instance API is not reachable, run with a CSV fallback:
+The script fetches OpenTreeMap species for `apidemo` from `https://www.opentreemap.org`, sorts them by label, and appends `Other / Unknown`.
+
+## Options
 
 ```bash
-node ./scripts/updateTreeSpeciesFromOtm.mjs --input-csv ./path/to/species.csv --output ./assets/data/treeSpeciesDataset.json
-```
-
-Optional API overrides:
-
-- `--base-url <url>`
-- `--instance <instance-url-name>`
-
-Example:
-
-```bash
+node ./scripts/updateTreeSpeciesFromOtm.mjs --output ./assets/data/treeSpeciesDataset.json
 node ./scripts/updateTreeSpeciesFromOtm.mjs --base-url https://example.org --instance apidemo
+node ./scripts/updateTreeSpeciesFromOtm.mjs --input-csv ./species.csv
 ```
 
-## Notes for OTM mapping
+| Option | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `--output` | path | `assets/data/treeSpeciesDataset.json` | Writes the generated JSON file. |
+| `--base-url` | URL | `OTM_BASE_URL` or `https://www.opentreemap.org` | Selects the OpenTreeMap host. |
+| `--instance` | string | `OTM_INSTANCE` or `apidemo` | Selects the OpenTreeMap instance. |
+| `--input-csv` | path | none | Uses a CSV fallback when API fetch fails. |
 
-- The dataset stores OTM-facing fields needed for later mapping work.
-- `usdaCode` and `iTreeCode` are currently nullable and intended to be populated when upstream source data is available.
+`OTM_BASE_URL` and `OTM_INSTANCE` are read only when the matching CLI option is omitted.
+
+## Output
+
+Each species item contains `key`, `label`, `commonName`, `scientificName`, `otmCode`, `usdaCode`, `iTreeCode`, and `searchText`.
+
+`usdaCode` and `iTreeCode` are currently `null` because the generator does not source those mappings.

--- a/TreeGuardiansExpo/eslint.config.js
+++ b/TreeGuardiansExpo/eslint.config.js
@@ -1,4 +1,3 @@
-// https://docs.expo.dev/guides/using-eslint/
 const { defineConfig } = require('eslint/config');
 const expoConfig = require('eslint-config-expo/flat');
 const globals = require('globals');

--- a/TreeGuardiansExpo/hooks/useMyTreesFilterModel.ts
+++ b/TreeGuardiansExpo/hooks/useMyTreesFilterModel.ts
@@ -12,7 +12,7 @@ export type TreeWithOwnership = Tree & {
 
 export type MyTreesSortKey = 'date_desc' | 'date_asc' | 'species_az' | 'health';
 export type MyTreesRoleFilter = 'all' | 'created' | 'guardian';
-/** Filter list: All health, or one of three simplified buckets. */
+/** Health filter buckets used by the My Trees overlay. */
 export type MyTreesHealthFilter = 'all' | 'good' | 'ok' | 'bad';
 
 export const MY_TREES_SORT_OPTIONS: { key: MyTreesSortKey; label: string }[] = [
@@ -29,7 +29,7 @@ export const MY_TREES_HEALTH_OPTIONS: { key: MyTreesHealthFilter; label: string 
   { key: 'bad', label: 'Bad' },
 ];
 
-/** Coarse group for the simplified Good / Ok / Bad filter (matches API health + disease). */
+/** Maps API health and disease fields into Good, Ok, or Bad list groups. */
 export function myTreesHealthListGroup(tree: TreeWithOwnership): 'good' | 'ok' | 'bad' {
   const key = myTreesHealthKey(tree);
   if (key === 'excellent' || key === 'good') return 'good';

--- a/TreeGuardiansExpo/lib/activityApi.ts
+++ b/TreeGuardiansExpo/lib/activityApi.ts
@@ -10,7 +10,7 @@ export type LocalActivityItem = {
   sortKey: number;
 };
 
-/** @deprecated Use LocalActivityItem */
+/** @deprecated Use `LocalActivityItem`. */
 export type LocalTreeActivityItem = LocalActivityItem;
 
 type RecentComment = {

--- a/TreeGuardiansExpo/lib/treeApi.ts
+++ b/TreeGuardiansExpo/lib/treeApi.ts
@@ -417,11 +417,11 @@ export async function deleteTreePhoto(
 
 export type TreeFeedItem = {
   item_type: 'tree_comment' | 'wildlife' | 'disease' | 'seen' | 'reply';
-  /** Server may send bigint as string */
+  /** Comment ID can arrive as a number or string. */
   comment_id: number | string;
   created_at: string;
   content: string | null;
-  /** Pipe-separated image URLs from server (comments / replies only) */
+  /** Comment and reply image URLs joined by the server with |||. */
   photo_urls?: string | null;
   extra: string | null;
   user_id?: number | null;

--- a/TreeGuardiansExpo/lib/treeEcoEstimates.ts
+++ b/TreeGuardiansExpo/lib/treeEcoEstimates.ts
@@ -73,14 +73,11 @@ export function estimateTreeEcoStats(input: EstimateInput): EstimateOutput {
     const diameterM = diameterCm / 100;
     const trunkRadiusM = diameterM / 2;
 
-    // Crown radius estimate from species + height
     const crownRadiusM = clamp(heightM * speciesMeta.canopySpreadFactor, 1.2, 12);
     const crownAreaM2 = Math.PI * crownRadiusM * crownRadiusM;
 
-    // leaf area estimate
     const leafArea = crownAreaM2 * speciesMeta.leafDensityFactor;
 
-    // biomass-like rules from trunk size + height
     const stemVolumeIndex = Math.PI * trunkRadiusM * trunkRadiusM * heightM;
 
     const carbonDioxideStored = stemVolumeIndex * 520 * speciesMeta.storageFactor;

--- a/TreeGuardiansExpo/objects/TreeDetails.ts
+++ b/TreeGuardiansExpo/objects/TreeDetails.ts
@@ -1,4 +1,4 @@
-// Tree photos
+/** Photo row attached to a tree or comment. */
 export type TreePhoto = {
   id?: number;
   image_url: string;
@@ -8,7 +8,7 @@ export type TreePhoto = {
 
 export type TreeHealthState = 'excellent' | 'good' | 'ok' | 'bad' | 'terrible';
 
-// information filled in dashboard
+/** Tree details collected and displayed by add/edit flows. */
 export type TreeDetails = {
     species?: string,
     wildlife?: string,
@@ -16,7 +16,7 @@ export type TreeDetails = {
     disease?: string,
     diseaseList?: string[],
     photos?: TreePhoto[],
-    notes?: string, // "seen" obervations or additional notes
+    notes?: string,
     diameter?: number,
     height?: number,
     circumference?: number,
@@ -30,11 +30,11 @@ export type TreeDetails = {
     health?: TreeHealthState
 }
 
-// when the tree is successfully placed
+/** Persisted tree with map coordinates and optional ownership metadata. */
 export type Tree = TreeDetails & TreeOwnership & {
     latitude: number;
     longitude: number;
-    id?: number; // optional but useful for referencing
+    id?: number;
 }
 
 export type TreeOwnership = {

--- a/TreeGuardiansExpo/scripts/bundleLeaflet.js
+++ b/TreeGuardiansExpo/scripts/bundleLeaflet.js
@@ -1,11 +1,5 @@
 #!/usr/bin/env node
-/**
- * Bundles Leaflet CSS and JS from node_modules into a JSON file
- * so the mobile WebView can load them locally instead of from a CDN.
- *
- * Run via: node scripts/bundleLeaflet.js
- * Also runs automatically after `npm install` via the postinstall hook.
- */
+/** Bundles Leaflet CSS and JS for the native WebView map. */
 
 const fs = require('fs');
 const path = require('path');

--- a/TreeGuardiansExpo/scripts/updateTreeSpeciesFromOtm.mjs
+++ b/TreeGuardiansExpo/scripts/updateTreeSpeciesFromOtm.mjs
@@ -128,9 +128,7 @@ async function fetchSpeciesFromApi(baseUrl, instance) {
           scientific_name: normalizeWhitespace(row.scientific_name),
         })),
       };
-    } catch {
-      // try next candidate
-    }
+    } catch {}
   }
 
   throw new Error(

--- a/TreeGuardiansExpo/styles/README.md
+++ b/TreeGuardiansExpo/styles/README.md
@@ -1,80 +1,34 @@
-## These are the current sub-themes that you can use:
+# Styles
 
-1. Colours
-    - primary: '#1B5E20' 
-    - secondary: '#6D4C41'    
-    - accent: '#48b54d'  
-    - background: '#F1F8F4'  
+`styles/index.ts` re-exports the app theme, layout helpers, and design tokens.
 
-    - white: '#FFFFFF'
-    - black: '#1C1C1C'
-    - gray: '#5F6368'
+Import shared styles from the package index:
 
-    - success: '#2E7D32'
-    - error: '#C62828'
-    - warning: '#F9A825'
+```ts
+import { Theme, getResponsiveLayoutMetrics } from '@/styles';
+```
 
-2. Spacing
-    - extraSmall: 4
-    - small: 8
-    - medium: 16
-    - large: 24
-    - extraLarge: 32
+## Tokens
 
-3. BorderRadius
-    - extraSmall: 3
-    - small: 6
-    - medium: 10
-    - large: 16
+| Token | Values |
+| --- | --- |
+| `Colours` | `primary`, `secondary`, `accent`, `backgroundSoft`, `textPrimary`, `textMuted`, `textLight`, `white`, `black`, `gray`, `success`, `error`, `warning` |
+| `Spacing` | `extraSmall: 4`, `small: 8`, `medium: 16`, `large: 24`, `extraLarge: 32` |
+| `Radius` | `extraSmall: 3`, `small: 6`, `medium: 10`, `large: 16`, `card: 20` |
+| `Border` | `extraSmall: 3`, `small: 6`, `medium: 10`, `large: 16` |
+| `Typography` | `title`, `subtitle`, `tagline`, `body`, `caption` |
 
-4. Typography
-    - title:
-      fontSize: 28
-      fontWeight: 700
-      lineHeight: 34
+## Theme
 
-    - subtitle:
-      fontSize: 20
-      fontWeight: 600
-      lineHeight: 26
-    
-    - body:
-      fontSize: 16
-      fontWeight: 400
-      lineHeight: 22
-    
-    - caption:
-      fontSize: 13
-      fontWeight: 400
-      lineHeight: 18
+`Theme` groups tokens and shared styles for `container`, `background`, `button`, and `dimOverlay`.
 
-## These are the themes that you can use: (TO BE UPDATED)
+## Layout
 
-1. Button
-    - primary:
-      backgroundColor: Colours.primary
-      padding: Spacing.medium
-      borderRadius: BorderRadius.small
+`getResponsiveLayoutMetrics(width, height)` returns breakpoint flags and reusable dimensions for compact, phone, tablet, and desktop layouts.
 
-    - secondary:
-      backgroundColor: Colours.secondary
-      padding: Spacing.medium
-      borderRadius: BorderRadius.small
+Breakpoints:
 
-    - text:
-      color: Colours.white
-      fontWeight: 'bold'
-
-2. container:
-    flex: 1,
-    backgroundColor: Colours.background,
-    padding: Spacing.medium,
-
-3. Dim Overlay:
-    position: 'absolute'
-    top: 0
-    left: 0
-    right: 0
-    bottom: 0
-    backgroundColor: 'rgba(255,255,255,0.5)'
-    zIndex: 50
+- `compact`: `< 380`
+- `phone`: `< 680`
+- `tablet`: `680..899`
+- `desktop`: `>= 900`

--- a/TreeGuardiansExpo/styles/tokens/colours.ts
+++ b/TreeGuardiansExpo/styles/tokens/colours.ts
@@ -1,25 +1,18 @@
 export const Colours = {
-  // Forest green — primary CTA
   primary: '#2E7D32',
-  // Lighter green — secondary / accents
   secondary: '#66BB6A',
-  // Soft accent green
   accent: '#A5D6A7',
 
-  // Soft off-white background
   backgroundSoft: '#F5F7F5',
 
-  // Text
   textPrimary: '#1B1B1B',
   textMuted: '#4A4A4A',
   textLight: '#8A8A8A',
 
-  // UI
   white: '#FFFFFF',
   black: '#1B1B1B',
   gray: '#5F6368',
 
-  // Semantic
   success: '#2E7D32',
   error: '#C62828',
   warning: '#F9A825',

--- a/TreeGuardiansExpo/utilities/authHelper.ts
+++ b/TreeGuardiansExpo/utilities/authHelper.ts
@@ -94,7 +94,6 @@ export async function validateSession(): Promise<AuthState> {
   }
 }
 
-// Load authentication state
 export async function getAuthState(): Promise<AuthState> {
   try {
     const token = await getItem("accessToken");
@@ -115,7 +114,6 @@ export async function getAuthState(): Promise<AuthState> {
   }
 }
 
-// Return current logged-in user
 export async function getCurrentUser(): Promise<AuthUser | null> {
   try {
     const token = await getItem("accessToken");
@@ -162,7 +160,6 @@ export function normalizeUserRole(role: UserRole | null | undefined): AppUserRol
   return "user";
 }
 
-// Return stored access token
 export async function getAccessToken(): Promise<string | null> {
   try {
     return await getItem("accessToken");
@@ -172,7 +169,6 @@ export async function getAccessToken(): Promise<string | null> {
   }
 }
 
-// Logout user
 export async function logoutUser(): Promise<boolean> {
   try {
     const refreshToken = await getItem("refreshToken");
@@ -370,7 +366,6 @@ export async function deleteAccount(payload: {
     await parseErrorResponse(response, "Failed to delete account.");
   }
 
-  // Server returns JSON; we don't depend on the shape.
   await response.json().catch(() => null as MessageResponse | null);
 }
 

--- a/TreeGuardiansExpo/utilities/phone.ts
+++ b/TreeGuardiansExpo/utilities/phone.ts
@@ -1,4 +1,3 @@
-// Optional phone validation, removes any white space inbetween the numbers, special characters like (), - but keeps the trailing + if present
 export function normalizePhone(phone: string): string {
   const trimmedPhone = phone.trim();
 
@@ -13,7 +12,7 @@ export function normalizePhone(phone: string): string {
 
 export function isValidPhone(phone: string): boolean {
   if (!phone) {
-    return true; // optional field
+    return true;
   }
 
   return /^\+?\d{7,15}$/.test(phone);

--- a/TreeGuardiansExpo/utilities/showAlert.ts
+++ b/TreeGuardiansExpo/utilities/showAlert.ts
@@ -1,6 +1,5 @@
 import { Alert, Platform } from "react-native";
 
-// To have alerts show on web or mobile
 export function showAlert(title: string, message: string, onOk?: () => void) {
   if (Platform.OS === "web") {
     window.alert(`${title}\n\n${message}`);

--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -1,6 +1,5 @@
 const jwt = require("jsonwebtoken");
 
-// General token authentication for logged-in users
 function authenticateToken(req, res, next) {
   const authHeader = req.headers["authorization"];
   const token = authHeader && authHeader.split(" ")[1];
@@ -12,7 +11,6 @@ function authenticateToken(req, res, next) {
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
 
-    // Optional: enforce token type
     if (decoded.type && decoded.type !== "auth") {
       return res.status(403).json({ error: "Invalid token type" });
     }
@@ -25,7 +23,6 @@ function authenticateToken(req, res, next) {
   }
 }
 
-// Password reset token verification
 function verifyResetToken(req, res, next) {
   const { token } = req.body;
 
@@ -36,12 +33,11 @@ function verifyResetToken(req, res, next) {
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
 
-    // Ensure it's a reset token
     if (decoded.type !== "reset") {
       return res.status(403).json({ error: "Invalid reset token" });
     }
 
-    req.user = decoded; // contains userId
+    req.user = decoded;
     next();
   } catch (error) {
     console.error("Reset token error:", error);

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -1,485 +1,93 @@
-# Local Setup and Stack Internals
+# Local Setup
 
-This document explains, in technical detail, how the local development stack works for `CT5038-TreeTracker`, where every moving part lives, and how to operate and debug it.
+The local stack runs the backend, database, Expo web build, Expo dev server, and Android emulator from one command.
 
-## 1. Purpose and Scope
-
-The local stack is designed to provide a one-command environment that approximates production shape while preserving a fast development loop.
-
-It orchestrates:
-
-- MySQL for local data persistence.
-- The Node backend (`server/`) running via the root entry point (`app.js`).
-- A continuously rebuilt Expo web export (`TreeGuardiansExpo/dist`) used by the backend as static assets.
-- A live Expo dev server for Expo Go workflows.
-- An Android emulator with noVNC for browser-accessible Android UI and auto-launch into Expo Go.
-
-Canonical command:
+## Start
 
 ```bash
 ./scripts/local_plesk_stack.sh
 ```
 
-Quiet mode (reduced terminal noise, full logs still captured):
+Use quiet mode when terminal output is too noisy:
 
 ```bash
-./scripts/local_plesk_stack.sh -q
+./scripts/local_plesk_stack.sh --quiet
 ```
 
-## 2. Canonical Resource Map
+Stop with `Ctrl+C`; the launcher runs `docker compose down --remove-orphans`.
 
-### 2.1 Orchestration and Launcher
+## Requirements
 
-- Canonical compose file: `docker/compose.local.yml`
-- Canonical launcher script: `scripts/local_plesk_stack.sh`
-- Local env defaults template: `.env.docker.example`
-- Active local env file: `.env.docker`
+- Docker Engine with the Compose plugin.
+- `/dev/kvm` available and readable/writable by the user running Docker.
+- `server/.env` and `.env.docker`; the launcher copies examples when either is missing.
 
-### 2.2 Docker Assets
+## Services
 
-- Dockerfiles:
-  - `docker/images/server.Dockerfile`
-  - `docker/images/expo.Dockerfile`
-  - `docker/images/android-emulator.Dockerfile`
-- Runtime helper scripts:
-  - `docker/scripts/watch-expo-web.sh`
-  - `docker/scripts/android-emulator-entrypoint.sh`
+| Service | Purpose | Main port |
+| --- | --- | --- |
+| `mysql` | MySQL 8.0 data store. | `3306` |
+| `expo-web-build` | Watches Expo source and writes `TreeGuardiansExpo/dist`. | none |
+| `server` | Runs `app.js`, `/api/*`, health routes, uploads, and static web output. | `4000` |
+| `expo` | Runs `npx expo start --go`. | `8081` |
+| `android-emulator` | Runs Expo Go in Android and exposes noVNC. | `6080` |
 
-### 2.3 Compatibility Path (Non-Canonical)
+## URLs
 
-- Compatibility compose file: `docker-compose.plesk-local.yml`
+- Web app and backend: `http://localhost:${SERVER_PORT}`; default `4000`.
+- Expo dev server: `http://localhost:${EXPO_DEV_SERVER_PORT}`; default `8081`.
+- Android emulator: `http://localhost:6080/vnc.html`.
 
-This file exists as a fallback compatibility path. The canonical path is `docker/compose.local.yml` via `scripts/local_plesk_stack.sh`.
+## Local Config
 
-### 2.4 App Components
+`.env.docker` is read by `scripts/local_plesk_stack.sh` and `docker/compose.local.yml`.
 
-- Root backend entry point: `app.js`
-- Backend app: `server/`
-- Backend DB schema: `server/src/db/schema.sql`
-- Expo app source: `TreeGuardiansExpo/`
-- Expo web output: `TreeGuardiansExpo/dist/`
+| Option | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `MYSQL_ROOT_PASSWORD` | string | `root` | Sets the local MySQL root password and the backend DB password. |
+| `MYSQL_DATABASE` | string | `treetracker_dev` | Creates and selects the local database. |
+| `SERVER_PORT` | integer | `4000` | Publishes the backend container. |
+| `EXPO_DEV_SERVER_PORT` | integer | `8081` | Publishes the Expo dev server. |
+| `EXPO_HOST_MODE` | `tunnel` or `lan` | `tunnel` | Selects Expo Go connection mode. |
+| `WEB_BUILD_DEBOUNCE_SECONDS` | integer | `2` | Poll interval for static web export rebuilds. |
 
-### 2.5 Logs
+Backend runtime config lives in `server/.env`; see [server/README.md](../server/README.md).
 
-- Host log directory: `logs/`
-- Common log files:
-  - `logs/mysql.log`
-  - `logs/server.log`
-  - `logs/expo.log`
-  - `logs/expo-web-build.log`
-  - `logs/android-emulator.log`
+## Files
 
-## 3. Prerequisites
+- Launcher: `scripts/local_plesk_stack.sh`.
+- Compose file: `docker/compose.local.yml`.
+- Compatibility compose file: `docker-compose.plesk-local.yml`.
+- Backend image: `docker/images/server.Dockerfile`.
+- Expo image: `docker/images/expo.Dockerfile`.
+- Emulator image: `docker/images/android-emulator.Dockerfile`.
+- Web export watcher: `docker/scripts/watch-expo-web.sh`.
+- Emulator entrypoint: `docker/scripts/android-emulator-entrypoint.sh`.
 
-### 3.1 Host Requirements
+## Logs
 
-- Linux host with Docker Engine and Docker Compose plugin.
-- Hardware virtualization enabled in BIOS/UEFI.
-- KVM device available and accessible (`/dev/kvm`) for the emulator container.
-
-The launcher hard-fails if `/dev/kvm` is absent.
-
-### 3.2 First-Time Project Prereqs
-
-- Ensure `.env.docker` exists. If missing, launcher copies `.env.docker.example`.
-- Ensure `server/.env` exists. If missing and `server/.env.example` exists, launcher copies it.
-
-## 4. Environment Configuration
-
-Values are read from `.env.docker`.
-
-Default template (`.env.docker.example`) defines:
-
-- `MYSQL_ROOT_PASSWORD=root`
-- `MYSQL_DATABASE=treetracker_dev`
-- `SERVER_PORT=4000`
-- `EXPO_DEV_SERVER_PORT=8081`
-- `EXPO_HOST_MODE=tunnel` (recommended default for Expo Go)
-- `WEB_BUILD_DEBOUNCE_SECONDS=2`
-
-Important behavior:
-
-- `EXPO_HOST_MODE=tunnel` is usually best for physical-device Expo Go.
-- `EXPO_HOST_MODE=lan` can be used when device and host are on same reachable LAN.
-
-## 5. What the Launcher Script Actually Does
-
-Script: `scripts/local_plesk_stack.sh`
-
-Execution sequence:
-
-1. Resolve root paths and select canonical compose file (`docker/compose.local.yml`).
-2. Parse script options (`-q/--quiet`, `-h/--help`) and pass-through compose args.
-3. Create `logs/` and normalize log ownership/permissions if needed.
-4. Validate `/dev/kvm` exists before startup.
-5. Bootstrap missing env files (`.env.docker`, optionally `server/.env`).
-6. Read and print startup URLs and mode:
-   - web (`SERVER_PORT`)
-   - expo (`EXPO_DEV_SERVER_PORT`)
-   - noVNC (`6080`)
-7. Start background per-service log streamers into `logs/*.log`.
-8. Start background scanner that extracts first `exp://...` link from `logs/expo.log` and prints it.
-9. Run compose `up` in fail-fast mode:
-   - `--abort-on-container-failure` is enabled.
-10. On exit (`EXIT`, `INT`, `TERM`), stop log streamers and run compose `down --remove-orphans`.
-
-### 5.1 Quiet vs Normal Mode
-
-Normal mode:
-
-- `docker compose up --build --remove-orphans --abort-on-container-failure`
-- Suppresses terminal attach for noisy services (`mysql`, `server`, `expo-web-build`) but still shows Expo/emulator output.
-
-Quiet mode:
-
-- Builds first with `docker compose build --quiet`.
-- Runs `up --no-build` and no-attaches several services including emulator.
-- Keeps terminal focused mainly on Expo while writing full logs to files.
-
-## 6. Compose Architecture (`docker/compose.local.yml`)
-
-Project name:
-
-- `ct5038-treetracker-local`
-
-Defined services:
-
-1. `mysql`
-2. `expo-web-build`
-3. `server`
-4. `expo`
-5. `android-emulator`
-
-Persistent volumes:
-
-- `mysql_data`
-- `server_node_modules`
-- `expo_node_modules`
-
-### 6.1 Service: `mysql`
-
-Role:
-
-- Database backend for local environment.
-
-Key settings:
-
-- Image: `mysql:8.0`
-- Port mapping: `3306:3306`
-- Volume: `mysql_data:/var/lib/mysql`
-- Healthcheck gate used by dependent backend startup.
-
-### 6.2 Service: `expo-web-build`
-
-Role:
-
-- Continuous source watcher that exports static web bundle into `TreeGuardiansExpo/dist`.
-
-Key settings:
-
-- Built from: `docker/images/expo.Dockerfile`
-- Command: `/workspace/docker/scripts/watch-expo-web.sh`
-- Uses mounted repo and persistent Expo node_modules volume.
-- Writes watch/build activity to `logs/expo-web-build.log`.
-
-Behavior details (`docker/scripts/watch-expo-web.sh`):
-
-- Computes a content hash over selected Expo source file types.
-- Ignores heavy/generated dirs (`node_modules`, `.expo`, `dist`, `android`, `ios`).
-- On hash change:
-  - Runs `npm install` for Expo app.
-  - Runs `npm run export:web`.
-- Sleeps with configurable debounce between checks.
-
-### 6.3 Service: `server`
-
-Role:
-
-- Main backend runtime serving API and static web assets.
-
-Key settings:
-
-- Built from: `docker/images/server.Dockerfile`
-- Command: `npm install --prefix /workspace/server && node --watch /workspace/app.js`
-- Port mapping: `${SERVER_PORT:-4000}:4000`
-- Depends on:
-  - `mysql` healthy
-  - `expo-web-build` started
-
-Critical env wiring:
-
-- DB points to `mysql` service network host.
-- `EXPO_STATIC_ENABLED=true`
-- `EXPO_WEB_DIST_PATH=/workspace/TreeGuardiansExpo/dist`
-- This means backend serves static web export generated by `expo-web-build`.
-
-### 6.4 Service: `expo`
-
-Role:
-
-- Live Expo dev server used by Expo Go clients.
-
-Key settings:
-
-- Built from: `docker/images/expo.Dockerfile`
-- Command:
+The launcher mirrors service logs into `logs/`.
 
 ```bash
-npm install && npx expo start --go --port ${EXPO_DEV_SERVER_PORT:-8081} --host ${EXPO_HOST_MODE:-tunnel} --clear
-```
-
-- Port mappings:
-  - `8081` (default, configurable)
-  - `19000`, `19001`, `19002`
-- Has interactive terminal flags (`stdin_open`, `tty`) for Expo tooling behavior.
-
-### 6.5 Service: `android-emulator`
-
-Role:
-
-- Containerized Android emulator plus noVNC endpoint.
-- Auto-installs/opens Expo Go and proxies backend/Expo endpoints into emulator localhost.
-
-Key settings:
-
-- Built from: `docker/images/android-emulator.Dockerfile`
-- Uses `/dev/kvm` passthrough for acceleration.
-- Port mappings:
-  - `6080` noVNC
-  - `5900` VNC
-- Depends on `expo` started.
-
-Runtime details (`docker/scripts/android-emulator-entrypoint.sh`):
-
-- Starts `Xvfb` display.
-- Verifies KVM readability/writability.
-- Boots Android emulator AVD (`expo-emulator`) with swiftshader software GPU mode.
-- Starts `x11vnc` and noVNC websockify/proxy.
-- Waits for ADB + full Android boot completion (`sys.boot_completed=1`).
-- Creates `adb reverse`-backed TCP proxies for:
-  - Backend (`server:4000` -> emulator localhost:4000)
-  - Expo (`expo:8081` -> emulator localhost:8081)
-- Resolves Expo target and launches `exp://127.0.0.1:8081` inside emulator.
-- Logs to `logs/android-emulator.log`.
-
-## 7. Docker Image Internals
-
-### 7.1 `docker/images/server.Dockerfile`
-
-- Base: `node:20-bookworm`
-- Installs minimal runtime packages + `tini`.
-- Uses `tini` entrypoint for cleaner signal handling.
-
-### 7.2 `docker/images/expo.Dockerfile`
-
-- Base: `node:20-bookworm`
-- Installs `@expo/ngrok` globally.
-- Needed for `expo start --host tunnel` flow without interactive install prompts.
-
-### 7.3 `docker/images/android-emulator.Dockerfile`
-
-- Base: `node:20-bookworm`
-- Installs Android SDK commandline tools, emulator, platform tools, system image.
-- Creates AVD (`expo-emulator`) at build time.
-- Attempts Expo Go APK resolution/download for configured SDK major (`EXPO_SDK_VERSION=54`).
-- Copies emulator entrypoint script and exposes emulator/VNC/noVNC ports.
-
-## 8. Network and Data Flow
-
-### 8.1 Backend + Web
-
-- Browser hits `http://localhost:${SERVER_PORT}`.
-- Backend process handles API routes and serves static files from `TreeGuardiansExpo/dist`.
-
-### 8.2 Expo Go Path
-
-- Expo service hosts dev bundle on `expo:8081` (inside compose network).
-- Android emulator service reverse-proxies this to emulator localhost (`127.0.0.1:8081`).
-- Emulator opens `exp://127.0.0.1:8081` via Expo Go.
-
-### 8.3 Emulator UI Path
-
-- noVNC endpoint at `http://localhost:6080/vnc.html` gives browser access to emulator display.
-
-### 8.4 Database Path
-
-- Backend uses compose DNS host `mysql` on `3306`.
-- Data persists in named volume `mysql_data`.
-
-## 9. Runtime Lifecycle and Failure Semantics
-
-The launcher uses fail-fast compose behavior (`--abort-on-container-failure`):
-
-- If a service exits non-zero, full stack is torn down.
-- This is intentional for quick signal of orchestration breakage.
-
-Implication:
-
-- Emulator instability can stop entire stack, even if backend/Expo are otherwise healthy.
-
-## 10. Logs and Observability
-
-Primary host-side logs:
-
-- `logs/mysql.log`
-- `logs/server.log`
-- `logs/expo.log`
-- `logs/expo-web-build.log`
-- `logs/android-emulator.log`
-
-Launcher behavior:
-
-- Starts per-service `docker compose logs -f` streamers writing to these files.
-- Prints discovered Expo deep link (`exp://...`) when found in `logs/expo.log`.
-
-Useful commands:
-
-```bash
-# Quick status
 docker compose --env-file .env.docker -f docker/compose.local.yml ps
-
-# Tail all logs
 tail -n 200 logs/*.log
-
-# Follow emulator log
 tail -f logs/android-emulator.log
 ```
 
-## 11. Typical Local Workflows
-
-### 11.1 Start Stack
+## Database Reset
 
 ```bash
-./scripts/local_plesk_stack.sh
+./scripts/local_plesk_stack.sh --reset
 ```
 
-### 11.2 Start in Quiet Mode
+`--reset` drops the configured local MySQL database after validating the database name.
 
-```bash
-./scripts/local_plesk_stack.sh -q
-```
+## Troubleshooting
 
-### 11.3 Stop Stack
+`/dev/kvm` missing or blocked: enable virtualization, install KVM, and add the current user to the host KVM access path.
 
-- Press `Ctrl+C` in launcher terminal.
-- Cleanup trap runs compose down automatically.
+Expo link missing: inspect `logs/expo.log` and look for the first `exp://` URL.
 
-Manual stop if needed:
+Web UI stale: inspect `logs/expo-web-build.log` and confirm `TreeGuardiansExpo/dist` is changing.
 
-```bash
-docker compose --env-file .env.docker -f docker/compose.local.yml down --remove-orphans
-```
-
-### 11.4 Rebuild from Scratch
-
-```bash
-docker compose --env-file .env.docker -f docker/compose.local.yml build --no-cache
-./scripts/local_plesk_stack.sh -q
-```
-
-## 12. Troubleshooting
-
-### 12.1 `/dev/kvm` Missing or Inaccessible
-
-Symptoms:
-
-- Launcher exits early with KVM error.
-- Emulator container exits immediately.
-
-Checks:
-
-```bash
-ls -l /dev/kvm
-```
-
-Fixes:
-
-- Enable virtualization in BIOS/UEFI.
-- Ensure host user/docker runtime can access `/dev/kvm`.
-
-### 12.2 Expo Link Not Printed
-
-Symptoms:
-
-- No `exp://` line appears.
-
-Checks:
-
-```bash
-grep -Eo 'exp://[^[:space:]]+' logs/expo.log | head -n 1
-```
-
-If empty:
-
-- Expo may still be booting.
-- Expo service may have failed startup; inspect `logs/expo.log`.
-
-### 12.3 Web UI Not Updating
-
-Symptoms:
-
-- Backend serves stale frontend.
-
-Checks:
-
-- `logs/expo-web-build.log` for watcher/build errors.
-- Confirm `TreeGuardiansExpo/dist` is being updated.
-
-### 12.4 Database Connectivity Issues
-
-Checks:
-
-- `mysql` healthcheck status in `docker compose ps`.
-- `DB_*` values in `.env.docker` and compose environment.
-
-### 12.5 Emulator Boots But Expo Go Does Not Open
-
-Checks:
-
-- `logs/android-emulator.log` for APK install/start warnings.
-- Verify expo service reachable and port 8081 proxying established.
-
-## 13. Relationship to Plesk/Production Shape
-
-Production and local intentionally differ in tooling, but share structure where it matters:
-
-- Backend entry point remains root-level (`app.js`).
-- Static web bundle path is `TreeGuardiansExpo/dist`.
-- Backend serves built web assets.
-
-Reference production docs:
-
-- `PLESK.md`
-- `plesk_deploy.sh`
-
-## 14. Quick Reference
-
-### 14.1 Key URLs
-
-- Web app: `http://localhost:${SERVER_PORT}` (default `4000`)
-- Expo dev server endpoint: `http://localhost:${EXPO_DEV_SERVER_PORT}` (default `8081`)
-- noVNC emulator: `http://localhost:6080/vnc.html`
-
-### 14.2 Key Commands
-
-```bash
-# Canonical start
-./scripts/local_plesk_stack.sh
-
-# Quiet mode
-./scripts/local_plesk_stack.sh -q
-
-# Stop everything
-docker compose --env-file .env.docker -f docker/compose.local.yml down --remove-orphans
-
-# Show service state
-docker compose --env-file .env.docker -f docker/compose.local.yml ps
-```
-
-### 14.3 Canonical Files to Check First When Debugging
-
-- `scripts/local_plesk_stack.sh`
-- `docker/compose.local.yml`
-- `docker/scripts/android-emulator-entrypoint.sh`
-- `docker/scripts/watch-expo-web.sh`
-- `logs/*.log`
+Database connection errors: check `docker compose ps`, `MYSQL_*` in `.env.docker`, and `DB_*` in `server/.env`.

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,42 +1,77 @@
-# Copy this file to server/.env and adjust values for the current environment.
+# Copy to server/.env. Existing process env values override this file.
 
+# type=string default=development effect: selects production defaults and error verbosity.
 NODE_ENV=development
+# type=integer default=4000 effect: backend HTTP listen port.
 PORT=4000
-
-DB_HOST=mysql
-DB_PORT=3306
-DB_USER=root
-DB_PASSWORD=root
-DB_DATABASE=treetracker_dev
-DB_CONNECTION_LIMIT=10
-DB_SLOW_QUERY_MS=200
-DB_ALLOW_CREATE_DATABASE=true
-DB_SCHEMA_PATH=/workspace/server/src/db/schema.sql
+# type=string default=required effect: signs access, email verification, and reset tokens.
 JWT_SECRET=your_jwt_secret_here
 
-FRONTEND_URL=http://localhost:8081
+# type=string default=required effect: MySQL host.
+DB_HOST=mysql
+# type=integer default=3306 effect: MySQL port.
+DB_PORT=3306
+# type=string default=required effect: MySQL user.
+DB_USER=root
+# type=string default=required effect: MySQL password.
+DB_PASSWORD=root
+# type=string default=required effect: MySQL database name.
+DB_DATABASE=treetracker_dev
+# type=integer default=10 effect: maximum MySQL pool connections.
+DB_CONNECTION_LIMIT=10
+# type=integer default=200 effect: logs queries at or above this duration in milliseconds.
+DB_SLOW_QUERY_MS=200
+# type=boolean default=true effect: creates DB_DATABASE on boot when missing.
+DB_ALLOW_CREATE_DATABASE=true
+# type=path default=server/src/db/schema.sql effect: schema snapshot used for migrations.
+DB_SCHEMA_PATH=/workspace/server/src/db/schema.sql
 
+# type=URL default=none effect: builds email verification and password reset links.
+FRONTEND_URL=http://localhost:8081
+# type=URL default=request origin effect: public base URL for uploaded files.
+UPLOAD_PUBLIC_BASE_URL=
+
+# type=debug|info|warn|error default=debug in development, info in production effect: minimum log level.
+LOG_LEVEL=
+# type=0|1 default=by NODE_ENV effect: forces terse or verbose HTTP error JSON.
+HTTP_VERBOSE_ERRORS=
+
+# type=boolean default=false effect: creates/updates local admin and guardian users.
 SEED_DEV_USERS=false
+# type=string default=required when SEED_DEV_USERS=true effect: password for seeded users.
 SEED_DEV_USERS_PASSWORD=
 
+# type=boolean default=true unless production effect: starts Expo from the backend process.
 START_EXPO=true
+# type=path default=repo TreeGuardiansExpo effect: Expo project directory.
 EXPO_PROJECT_PATH=/workspace/TreeGuardiansExpo
+# type=integer default=8081 effect: Expo dev server port.
 EXPO_DEV_SERVER_PORT=8081
+# type=boolean default=START_EXPO effect: proxies unmatched backend routes to Expo.
 EXPO_PROXY_ENABLED=true
+# type=boolean default=!START_EXPO effect: serves Expo web export from EXPO_WEB_DIST_PATH.
 EXPO_STATIC_ENABLED=false
+# type=path default=EXPO_PROJECT_PATH/dist effect: static web root.
 EXPO_WEB_DIST_PATH=/workspace/TreeGuardiansExpo/dist
+# type=boolean default=!START_EXPO effect: installs Expo deps if missing and runs export:web before HTTP starts.
 EXPO_AUTO_PREPARE=false
+# type=IP default=0.0.0.0 effect: bind address for spawned Expo devtools.
 EXPO_DEVTOOLS_LISTEN_ADDRESS=0.0.0.0
+# type=boolean default=false effect: marks backend failed if spawned Expo exits non-zero.
 EXPO_FATAL_ON_EXIT=false
 
+# type=boolean default=false; forced false in production effect: exposes DB endpoint invocation routes.
 DB_TEST_BENCH_ENABLED=false
+# type=string default=required when DB_TEST_BENCH_ENABLED=true effect: bearer or x-testbench-token value.
 DB_TEST_BENCH_TOKEN=
 
+# type=string default=none effect: SMTP host used by verification and reset emails.
 SMTP_HOST=smtp-relay.brevo.com
+# type=integer default=none effect: SMTP port.
 SMTP_PORT=587
+# type=string default=none effect: SMTP username.
 SMTP_USER=xxxx@smtp-brevo.com
+# type=email default=none effect: sender address.
 SMTP_FROM=treeguardians0@gmail.com
+# type=string default=none effect: SMTP password.
 SMTP_PASS=your_smtp-brevo_password
-
-MYSQL_ROOT_PASSWORD=root
-MYSQL_DATABASE=treetracker_dev

--- a/server/README.md
+++ b/server/README.md
@@ -1,158 +1,198 @@
-# Tree Tracker Node Backend
+# Backend
 
-This server is the backend runtime that loads `server/.env`, initializes the database middleware, and optionally starts Expo for local development.
+The backend loads environment values, initializes MySQL, exposes `/api/*`, stores uploads, and optionally serves or prepares the Expo web export.
 
-The canonical server requirements are in `ServerRequirements.md` at the repository root.
+## Run
 
-## Database Lock Rules
+```bash
+npm install
+npm start
+```
 
-- DB client creation is runtime-locked: direct `mysql2` client factories (`createPool`, `createConnection`) are blocked outside `server/src/db/**`.
-- Second-layer runtime lock guards `query`/`execute` on created clients, so leaked client objects cannot run SQL from outside middleware.
-- Application code outside `server/src/db/**` must use exported database endpoint groups from `server/src/db/index.js`.
-- Direct SQL access attempts outside middleware throw `DB_LOCK_VIOLATION`.
+Tests:
 
-### Endpoint Groups
+```bash
+npm test
+npm run test:integration
+```
 
-- Table groups: `users`, `userPasswords`, `admins`, `userSessions`, `trees`, `treeCreationData`, `treeData`, `guardians`, `photos`, `treePhotos`, `comments`, `commentPhotos`, `commentsTree`, `commentReplies`, `wildlifeObservations`, `diseaseObservations`, `seenObservations`.
-- Workflow groups: `workflows.auth`, `workflows.trees`, `workflows.photos`, `workflows.comments`, `workflows.observations`, `workflows.users`.
-
-The lock is enforced in software by `server/src/db/runtime-lock.js`, and verified by the backend lock tests in `server/test/db.lock.test.js`.
+`test:integration` requires a reachable MySQL server and `RUN_DB_TESTS=true`.
 
 ## Boot Flow
 
-- Load `server/.env` via `server/bootstrap.js`, without overwriting already-set process env values.
-- Parse env configuration via `server/src/config.js`.
-- Run `await db.init(config.db)`.
-- Start HTTP health endpoints (`/health`, `/db/health`).
-- In development (`START_EXPO=true` and non-production), spawn `npx expo start` in `EXPO_PROJECT_PATH`.
-- In local Docker development, unmatched HTTP routes are proxied to Expo so `http://localhost:4000/` behaves like the Expo dev entrypoint while `/health` and `/db/health` stay on the backend.
-- In production or Plesk (`START_EXPO=false`), unmatched `GET`/`HEAD` routes can serve the exported Expo web build from `EXPO_WEB_DIST_PATH` so `https://your-site/` opens the Expo app instead of returning backend `404`.
-- On `SIGINT`/`SIGTERM`, stop Expo child, stop HTTP server, then close DB pool.
+1. `server/bootstrap.js` loads `server/.env` without overwriting existing process env values.
+2. `server/src/config.js` validates runtime config.
+3. `server/src/main.js` prepares Expo web output when enabled, initializes DB, seeds dev users when enabled, and starts HTTP.
+4. `server/src/http.js` mounts health routes, optional DB testbench routes, `/api`, `/uploads`, Expo proxying, and static web fallback.
+5. `SIGINT` and `SIGTERM` stop Expo, HTTP, and DB in order.
 
-## Plesk Deployment For Expo Web
+## HTTP Routes
 
-Use Plesk to run the Node server from `server/`, and let that server publish the Expo web app at the site root.
+All API routes are mounted under `/api`.
 
-### Option 1: Plesk Startup Only
+| Route | Method | Auth | Effect |
+| --- | --- | --- | --- |
+| `/health` | `GET` | no | Returns process health. |
+| `/db/health` | `GET` | no | Returns DB readiness. |
+| `/api/` | `GET` | no | Returns API version text. |
+| `/api/auth/register`, `/api/register` | `POST` | no | Creates user, password, session, and optional email verification token. |
+| `/api/auth/login`, `/api/login` | `POST` | no | Creates access and refresh tokens. |
+| `/api/auth/logout`, `/api/logout` | `POST` | refresh token body | Deletes a refresh token. |
+| `/api/auth/verify-email` | `GET` | token query | Marks email verified. |
+| `/api/auth/resend-verification` | `POST` | bearer token | Sends a new verification email. |
+| `/api/auth/forgot-password` | `POST` | no | Sends a password reset link when the email exists. |
+| `/api/auth/reset-password` | `POST` | action token body | Replaces the password hash. |
+| `/api/users/me`, `/api/me` | `GET` | bearer token | Returns the current user. |
+| `/api/account/username` | `PUT` | bearer token | Updates username. |
+| `/api/account/email` | `PUT` | bearer token | Updates email and revokes verification. |
+| `/api/account/password` | `PUT` | bearer token | Changes password after current-password check. |
+| `/api/account/delete` | `DELETE` | bearer token | Deletes the current account after password check. |
+| `/api/trees`, `/api/add-tree-data` | `POST` | verified bearer token | Adds a tree inside the Charlton Kings boundary. |
+| `/api/trees`, `/api/get-trees` | `GET` | no | Lists trees with latest data, observations, photos, creator, and guardians. |
+| `/api/trees/recent` | `GET` | no | Lists recent tree creations. |
+| `/api/trees/:treeId`, `/api/get-tree-details` | `GET` | no | Returns one tree and its latest data row. |
+| `/api/trees/:treeId` | `PATCH` | bearer token | Updates tree data and optional notes. |
+| `/api/trees/:treeId` | `DELETE` | admin bearer token | Deletes a tree. |
+| `/api/trees/:treeId/photos`, `/api/upload-photos` | `POST` | bearer token | Uploads or attaches tree photos. |
+| `/api/trees/:treeId/photos/:photoId` | `DELETE` | admin bearer token | Removes a tree photo link and deletes orphaned photo rows/files. |
+| `/api/trees/:treeId/comment-photos` | `POST` | bearer token | Uploads draft photos for comments. |
+| `/api/trees/:treeId/comments` | `POST` | bearer token | Adds a text and/or photo comment. |
+| `/api/trees/:treeId/comment-replies` | `POST` | bearer token | Adds a reply using `parentCommentId` in JSON. |
+| `/api/trees/:treeId/comments/:parentCommentId/replies` | `POST` | bearer token | Adds a reply using the nested route. |
+| `/api/trees/:treeId/feed` | `GET` | no | Lists comments, replies, wildlife, disease, and seen observations. |
+| `/api/comments/recent` | `GET` | no | Lists recent tree comments. |
+| `/api/comments/:commentId` | `DELETE` | admin bearer token | Deletes a tree comment or reply. |
+| `/api/admin/users` | `GET` | admin bearer token | Lists users with roles and guardian tree IDs. |
+| `/api/admin/users/:userId/role` | `PATCH` | admin bearer token | Sets `registered_user`, `guardian`, or `admin`. |
+| `/api/admin/users/:userId/guardian-trees` | `POST` | admin bearer token | Assigns a guardian to a tree. |
+| `/api/admin/users/:userId/guardian-trees/:treeId` | `DELETE` | admin bearer token | Removes guardian assignment. |
+| `/api/admin/users/:userId/activity` | `GET` | admin bearer token | Returns recent comments and created trees. |
+| `/api/admin/users/:userId` | `DELETE` | admin bearer token | Deletes another user. |
+| `/api/analytics` | `GET` | admin bearer token | Returns tree, user, and impact totals. |
+| `/api/analytics/activity` | `GET` | admin bearer token | Returns daily tree/comment/user/login counts for 1 to 90 days. |
+| `/api/analytics/users` | `GET` | admin bearer token | Returns role counts and top contributors. |
 
-Use this if Plesk can just start a Node app and you do not want a separate deploy script.
+JSON requests must use `Content-Type: application/json` or a JSON-compatible media type. JSON bodies are limited to 1 MB. Uploads accept JPEG, PNG, WEBP, and GIF files up to 10 MB each, with at most 12 files per request.
 
-1. Copy `server/.env.example` to `server/.env` on the server and set the production values there.
+## Common Requests
 
-2. In Plesk, configure the Node app to run from `server/` with startup file `bootstrap.js` or `app.js`.
+Authenticated routes expect:
 
-3. Press deploy in Plesk. On startup, the backend will:
-
-- install Expo dependencies in `TreeGuardiansExpo/` if `node_modules/` is missing
-- run `npm run export:web`
-- create the configured database if it is missing and `DB_ALLOW_CREATE_DATABASE=true`
-- apply schema migrations
-
-Then the backend will serve the generated `TreeGuardiansExpo/dist/` build from `/`.
-
-### Option 2: Plesk Deploy Script
-
-Use this if you want Plesk to prepare the build before the Node app starts.
-
-1. Copy `server/.env.example` to `server/.env` on the server and set the production values there.
-
-2. In Plesk, configure the Node app to run from `server/` with startup file `bootstrap.js` or `app.js`.
-
-3. Set the deployment command to:
-
-```bash
-bash ./scripts/plesk-deploy.sh
+```http
+Authorization: Bearer <accessToken>
 ```
 
-4. Press deploy in Plesk. The deploy script will:
-
-- install Expo dependencies in `TreeGuardiansExpo/`
-- install backend dependencies in `server/`
-- run `npm run export:web`
-
-Then the backend startup will load `server/.env`, create the configured database if required, apply schema migrations, and serve the generated `TreeGuardiansExpo/dist/` build from `/`.
-
-With that setup:
-
-- `/` serves the Expo web app.
-- Expo assets under `/_expo/*` are served directly.
-- Backend endpoints like `/health` and `/db/health` still work from the same Node process.
-
-If you want the backend to rebuild the Expo web bundle again on every startup instead of relying on the deploy script, set `EXPO_AUTO_PREPARE=true`.
-
-## `.env` Usage
-
-- Commit `server/.env.example`; do not commit `server/.env`.
-- Keep a different untracked `server/.env` file in each environment, including Plesk and local Docker.
-- Existing process env values take precedence over `server/.env`, so Plesk or Docker can still override individual settings when needed.
-- Local Docker commands in `scripts/` now expect `server/.env` to exist before they start.
-
-## How To Add A DB Endpoint
-
-1. Add validation first in `server/src/db/validation.js` if needed.
-2. Add endpoint function under the right table group in `server/src/db/index.js`.
-3. Keep SQL in middleware only and use prepared statements (`?` placeholders).
-4. For multi-table writes, implement via `transaction(async (tx) => ...)`.
-5. Add or update tests in `server/test/`.
-
-## Manual DB Test Bench API (Development)
-
-By default, DB testbench routes are disabled.
-
-Enable explicitly with `DB_TEST_BENCH_ENABLED=true` (never enabled automatically in production). For secure usage, set `DB_TEST_BENCH_TOKEN` and pass it either as:
-
-- `Authorization: Bearer <token>`
-- `x-testbench-token: <token>`
-
-When enabled, the server exposes:
-
-- `GET /db/testbench/endpoints` returns all callable middleware endpoints.
-- `POST /db/testbench/invoke` executes any endpoint by name.
-
-`POST /db/testbench/invoke` requires `Content-Type: application/json` and body format:
+Create a tree with a verified account:
 
 ```json
 {
-	"endpoint": "users.list",
-	"args": [{ "limit": 10, "offset": 0 }]
+  "latitude": 51.8865,
+  "longitude": -2.0475,
+  "species": "English Oak",
+  "health": "good",
+  "notes": "Recently planted.",
+  "wildlifeList": ["birds"],
+  "diseaseList": []
 }
 ```
 
-Read-only database inspection helpers are available under the `debug.*` endpoint group:
+`POST /api/trees` requires coordinates inside the Charlton Kings boundary and returns `{ "success": true, "tree_id": 123 }`.
 
-- `debug.listTables()`
-- `debug.countRows(tableName)`
-- `debug.listRows(tableName, { limit, offset, order })`
-- `debug.previewAll({ limit, order })`
+Attach photos to a tree with multipart field `photos`.
 
-## Docker Usage
+Add a comment after uploading draft comment photos:
 
-Build the production server image:
-
-```bash
-docker build -t tree-tracker-server -f server/Dockerfile --target production .
+```json
+{
+  "content": "Canopy looks healthy.",
+  "photoIds": [12, 13]
+}
 ```
 
-Run the local development stack with MySQL and the Android emulator via Compose:
+`POST /api/trees/:treeId/comments` requires non-empty `content`, at least one `photoIds` entry, or both.
 
-```bash
-docker compose -f docker-compose.server.yml up --build server android-emulator
+## Error Shape
+
+Errors return JSON:
+
+```json
+{ "error": "Message", "code": "ValidationError" }
 ```
 
-The `server` service runs the Node backend and launches Expo from the mounted `TreeGuardiansExpo/` project. The `android-emulator` service installs the Android SDK, creates an emulator, exposes VNC on `localhost:5900`, and exposes noVNC on `http://localhost:6080/vnc.html`. Inside the emulator, both `localhost:4000` and `localhost:8081` are wired back to the server container through `adb reverse`.
+`HTTP_VERBOSE_ERRORS=1` adds request, body, and cause-chain debug fields. Defaults are verbose in development and terse in production.
 
-Before running Docker locally, copy `server/.env.example` to `server/.env` and keep Docker-specific values there.
+## Environment
 
-For the normal local development workflow, run:
+| Option | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `NODE_ENV` | string | `development` | Selects production defaults and error verbosity. |
+| `PORT` | integer | `4000` | HTTP listen port. |
+| `JWT_SECRET` | string | required | Signs auth and action tokens. |
+| `DB_HOST` | string | required | MySQL host. |
+| `DB_PORT` | integer | `3306` | MySQL port. |
+| `DB_USER` | string | required | MySQL user. |
+| `DB_PASSWORD` | string | required | MySQL password. |
+| `DB_DATABASE` | string | required | MySQL database name. |
+| `DB_CONNECTION_LIMIT` | integer | `10` | MySQL pool size. |
+| `DB_SLOW_QUERY_MS` | integer | `200` | Logs queries at or above this duration. |
+| `DB_ALLOW_CREATE_DATABASE` | boolean | `true` | Creates the database during boot when missing. |
+| `DB_SCHEMA_PATH` | path | `server/src/db/schema.sql` | SQL schema file used for snapshot migrations. |
+| `FRONTEND_URL` | URL | none | Base URL for verification and reset email links. |
+| `UPLOAD_PUBLIC_BASE_URL` | URL | request origin | Public base for uploaded file URLs. |
+| `LOG_LEVEL` | `debug`, `info`, `warn`, `error` | `debug` in development, `info` in production | Minimum structured log level. |
+| `HTTP_VERBOSE_ERRORS` | `0` or `1` | by `NODE_ENV` | Forces verbose or terse error JSON. |
+| `SEED_DEV_USERS` | boolean | `false` | Creates or updates `admin` and `guardian` dev users. |
+| `SEED_DEV_USERS_PASSWORD` | string | required when seeding | Password assigned to seeded dev users. |
+| `START_EXPO` | boolean | `true` unless production | Starts `npx expo start` from the backend process. |
+| `EXPO_PROJECT_PATH` | path | repo `TreeGuardiansExpo` | Expo project path. |
+| `EXPO_DEV_SERVER_PORT` | integer | `8081` | Expo dev server port. |
+| `EXPO_PROXY_ENABLED` | boolean | `START_EXPO` | Proxies unmatched backend routes to Expo. |
+| `EXPO_STATIC_ENABLED` | boolean | `!START_EXPO` | Serves static Expo web output for unmatched `GET`/`HEAD` routes. |
+| `EXPO_WEB_DIST_PATH` | path | `EXPO_PROJECT_PATH/dist` | Static web root. |
+| `EXPO_AUTO_PREPARE` | boolean | `!START_EXPO` | Installs Expo dependencies if missing and runs `npm run export:web`. |
+| `EXPO_DEVTOOLS_LISTEN_ADDRESS` | IP | `0.0.0.0` | Bind address passed to spawned Expo. |
+| `EXPO_FATAL_ON_EXIT` | boolean | `false` | Marks backend process failed if spawned Expo exits non-zero. |
+| `DB_TEST_BENCH_ENABLED` | boolean | `false`; forced `false` in production | Enables DB endpoint invocation routes. |
+| `DB_TEST_BENCH_TOKEN` | string | none | Required token when the DB testbench is enabled. |
+| `SMTP_HOST` | string | none | SMTP host for outbound email. |
+| `SMTP_PORT` | integer | none | SMTP port. |
+| `SMTP_USER` | string | none | SMTP username. |
+| `SMTP_PASS` | string | none | SMTP password. |
+| `SMTP_FROM` | email | none | Sender address. |
 
-```bash
-./scripts/start_local_server.sh
+## DB Middleware
+
+Application code should use `server/src/db/index.js`, not raw MySQL clients.
+
+`server/src/db/runtime-lock.js` blocks `mysql2` client factories outside `server/src/db/**` and blocks `query`/`execute` unless called inside DB middleware access context. Violations throw `DB_LOCK_VIOLATION`.
+
+Exported groups:
+
+- Account: `users`, `userPasswords`, `admins`, `guardianUsers`, `userSessions`, `emailVerificationTokens`.
+- Trees: `trees`, `treeCreationData`, `treeData`, `guardians`.
+- Content: `photos`, `treePhotos`, `comments`, `commentPhotos`, `commentsTree`, `commentReplies`, `wildlifeObservations`, `diseaseObservations`, `seenObservations`.
+- Workflows: `workflows.auth`, `workflows.trees`, `workflows.photos`, `workflows.comments`, `workflows.observations`, `workflows.users`, `workflows.analytics`.
+- Debug: `debug.listTables`, `debug.countRows`, `debug.listRows`, `debug.previewAll`.
+
+All public DB methods validate inputs and throw `ValidationError`, `NotFoundError`, `ConflictError`, `AuthError`, or `DbError` where applicable.
+
+## DB Testbench
+
+Enable only in development:
+
+```env
+DB_TEST_BENCH_ENABLED=true
+DB_TEST_BENCH_TOKEN=strong-local-token
 ```
 
-That starts the full development stack in the foreground. The server container watches backend files, Expo reloads frontend changes, the Android container opens Expo inside the emulator automatically, and the script tears everything down when you press `Ctrl+C`. Runtime logs are mirrored into the repository `logs/` directory for each container.
+Authenticate with `Authorization: Bearer <token>` or `x-testbench-token: <token>`.
 
-Run backend lock checks and tests inside containers (unit + integration):
+- `GET /db/testbench/endpoints` lists callable DB endpoints.
+- `POST /db/testbench/invoke` calls an endpoint with JSON body:
 
-```bash
-docker compose -f docker-compose.server.yml --profile test up --build --abort-on-container-exit --exit-code-from server-test server-test
+```json
+{
+  "endpoint": "users.list",
+  "args": [{ "limit": 10, "offset": 0 }]
+}
 ```

--- a/server/src/db/runtime-lock.js
+++ b/server/src/db/runtime-lock.js
@@ -6,7 +6,7 @@ const mysqlPromise = require("mysql2/promise");
 const DB_ROOT = path.resolve(__dirname).replace(/\\/g, "/");
 let installed = false;
 
-// Cheap per-call context flag — set by runWithDbAccess() at middleware entrypoints.
+// Marks call stacks that are allowed to execute SQL.
 const dbAccessStore = new AsyncLocalStorage();
 
 function isDbAccessAllowed() {
@@ -142,7 +142,7 @@ function wrapClient(client) {
     writable: false
   });
 
-  // Second-layer lock: block raw SQL execution even if a client leaks outside middleware.
+  // Guard leaked clients as well as client factories.
   wrapClientMethod(client, "query");
   wrapClientMethod(client, "execute");
   wrapGetConnection(client);
@@ -156,7 +156,7 @@ function installDbClientLock() {
     return;
   }
 
-  // Lock both callback and promise APIs to block direct pool/connection creation.
+  // Cover callback and promise mysql2 APIs.
   lockFactory(mysql, "createConnection");
   lockFactory(mysql, "createPool");
   lockFactory(mysql, "createPoolCluster");

--- a/server/src/db/test-helpers/lock-fixtures.js
+++ b/server/src/db/test-helpers/lock-fixtures.js
@@ -2,7 +2,6 @@ const mysql = require("mysql2");
 const mysqlPromise = require("mysql2/promise");
 
 function createLeakedPromisePool() {
-  // Created inside db middleware path so factory lock allows creation.
   return mysqlPromise.createPool({
     host: "127.0.0.1",
     port: 3306,
@@ -14,8 +13,6 @@ function createLeakedPromisePool() {
 }
 
 function createLeakedCallbackPool() {
-  // Created inside db middleware path so factory lock allows creation.
-  // Returns a callback-style pool, which exposes .promise() for conversion.
   return mysql.createPool({
     host: "127.0.0.1",
     port: 3306,

--- a/server/src/db/validation.js
+++ b/server/src/db/validation.js
@@ -26,7 +26,7 @@ function ensureRequiredString(name, value, max) {
   assert(value.length <= max, `${name} must be <= ${max} chars`);
 }
 
-/** String that may be empty (e.g. image-only comment body stored as ''). */
+/** Allows empty strings for image-only comment bodies. */
 function ensureStringAllowEmptyMax(name, value, max) {
   assert(typeof value === "string", `${name} must be a string`);
   assert(value.length <= max, `${name} must be <= ${max} chars`);

--- a/server/src/http.js
+++ b/server/src/http.js
@@ -432,7 +432,6 @@ function createHttpServer({
 
   app.use(express.json({ limit: MAX_JSON_BODY_BYTES }));
   app.use(express.urlencoded({ extended: true, limit: MAX_JSON_BODY_BYTES }));
-  // The global error handler at the bottom already handles entity too large. Which is why this block is removed
   app.use("/uploads", express.static(DEFAULT_UPLOADS_DIR));
 
   app.use(createHealthRouter({ db }));

--- a/server/src/main.js
+++ b/server/src/main.js
@@ -123,7 +123,6 @@ async function ensureDefaultDevUsers(defaultPassword) {
 }
 
 async function bootstrap({ exitOnShutdown = false, envPath = null } = {}) {
-  // Load env
   if (envPath) {
     require("dotenv").config({ path: envPath });
   } else {

--- a/server/src/routes/api/account.js
+++ b/server/src/routes/api/account.js
@@ -121,7 +121,6 @@ function createAccountRoute({ db, frontendUrl }) {
       return buildSafeUserResponse(userId, tx);
     });
 
-    // Send verification email to the new address
     if (verificationToken) {
       const verifyUrl = `${getFrontendUrl()}/verify-email?token=${verificationToken}`;
 
@@ -266,11 +265,6 @@ function createAccountRoute({ db, frontendUrl }) {
       return;
     }
 
-    // DB-level constraints handle data handling:
-    // - user_passwords + sessions: cascaded
-    // - guardian_trees: cascaded
-    // - tree_creation_data.creator_user_id: set to NULL
-    // - comments.user_id: set to NULL (anonymised)
     routeLog.info("request.success", { userId });
     res.json({ message: "Account deleted successfully" });
   };

--- a/server/src/routes/api/auth.js
+++ b/server/src/routes/api/auth.js
@@ -213,7 +213,6 @@ function createAuthRoute({ db, frontendUrl }) {
       }
 
       if (user.verified_at) {
-        // Still clean up the token if somehow it wasn't deleted before
         await db.emailVerificationTokens.deleteByToken(token);
         routeLog.info("verify.already_verified", { userId: user.id });
         return res.json({ message: "Email already verified" });
@@ -248,7 +247,6 @@ function createAuthRoute({ db, frontendUrl }) {
         return res.status(400).json({ error: "Email is already verified." });
       }
 
-      // Delete any existing tokens for this user and issue a fresh one
       await db.emailVerificationTokens.deleteByUserId(user.id);
       const verificationToken = await db.emailVerificationTokens.create(user.id);
 

--- a/server/src/routes/api/index.js
+++ b/server/src/routes/api/index.js
@@ -11,8 +11,7 @@ function createApiRouter(deps) {
   const router = express.Router();
 
   router.use(createApiRootRoute(deps));
-  // Multipart /trees/:treeId/photos and /comment-photos must resolve reliably; mount uploads
-  // before trees so those POST routes are hit first (avoids 404 if trees router stack differs).
+  // Upload routes must precede tree routes because they share /trees/:treeId prefixes.
   router.use(createUploadsRoute(deps));
   router.use(createTreesRoute(deps));
   router.use(createAuthRoute(deps));

--- a/server/src/routes/api/trees.js
+++ b/server/src/routes/api/trees.js
@@ -379,7 +379,6 @@ function createTreesRoute({ db }) {
 
     const limit = parsePositiveInt(req.query.limit || 6, "limit");
 
-    // Fetch recent creation records
     const recent = await db.treeCreationData.list({
       limit,
       offset: 0,

--- a/server/src/routes/api/uploads.js
+++ b/server/src/routes/api/uploads.js
@@ -353,9 +353,7 @@ function normalizeCommentPhotoIds(body) {
     .slice(0, 12);
 }
 
-/**
- * JSON reply endpoints live here so they match the same router as comment-photos (mounted first in api/index).
- */
+/** Registers JSON comment-reply routes on the upload router so shared prefixes resolve before tree routes. */
 function registerTreeCommentReplyJsonRoutes(router, { db }) {
   router.post(
     "/trees/:treeId/comment-replies",
@@ -434,7 +432,7 @@ function registerTreeCommentReplyJsonRoutes(router, { db }) {
   );
 }
 
-/** Registers POST /trees/:treeId/photos and POST /trees/:treeId/comment-photos (used by createUploadsRoute). */
+/** Registers multipart tree-photo and draft comment-photo upload routes. */
 function registerTreeScopedMultipartRoutes(router, deps) {
   const { upload, uploadHandler, commentPhotoUploadHandler } = createTreeScopedUploadFactories(deps);
 

--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -120,7 +120,6 @@ function createUsersRoute({ db }) {
       return res.status(400).json({ error: "Valid userId and treeId are required." });
     }
 
-    // Check the target user is verified before assigning them as guardian
     const targetUser = await db.users.getById(userId);
     if (!targetUser) {
       return res.status(404).json({ error: "User not found." });

--- a/server/src/routes/api/utils/http.js
+++ b/server/src/routes/api/utils/http.js
@@ -35,7 +35,7 @@ function getUploadPublicBase(req, explicitBase) {
 }
 
 function requireJson(req) {
-  // Accept application/json and common aliases (charset, +json types).
+  // Accept application/json plus charset and +json variants.
   if (!req.is("application/json") && !req.is("json")) {
     const error = new Error("Content-Type must be application/json");
     error.name = "UnsupportedMediaTypeError";


### PR DESCRIPTION
This pull request updates project documentation and configuration to reflect the current architecture and deployment process, improves clarity for new contributors, and cleans up code comments in the analytics admin page. The main changes are a rewritten `README.md` and `PLESK.md` for accurate setup and deployment instructions, a new Expo app README, and minor workflow and code comment cleanups.

**Documentation updates:**

* The main `README.md` is rewritten to describe the new Expo/Node stack, local Docker workflow, and how to run and test the project, replacing the old PHP/Dev Container instructions. It links to further docs for backend, Expo, and deployment details.
* `PLESK.md` is rewritten for clarity and accuracy, detailing the Plesk deployment process, environment variables, deployment script, checks, and common failures. Outdated and redundant sections are removed.
* A new `TreeGuardiansExpo/README.md` is added, documenting how to run the Expo app, its structure, environment variables, and links to component/style docs.

**Configuration and workflow:**

* Dependabot config (`.github/dependabot.yml`) is cleaned up by removing comments and unnecessary whitespace.
* Workflow file (`.github/workflows/lint.yml`) is cleaned up by removing section comments for a more concise jobs list. [[1]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L12-L14) [[2]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L44-L46) [[3]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L63-L65)

**Code cleanup:**

* Unused or redundant section comments are removed from the admin analytics page (`TreeGuardiansExpo/app/(protected)/admin/analytics.tsx`) for better readability. [[1]](diffhunk://#diff-c388f8db50ebb181ed32a5b56f51a632839580ad0855e55a6a57b449081ca37aL21-L22) [[2]](diffhunk://#diff-c388f8db50ebb181ed32a5b56f51a632839580ad0855e55a6a57b449081ca37aL173-L174) [[3]](diffhunk://#diff-c388f8db50ebb181ed32a5b56f51a632839580ad0855e55a6a57b449081ca37aL213-L214) [[4]](diffhunk://#diff-c388f8db50ebb181ed32a5b56f51a632839580ad0855e55a6a57b449081ca37aL257-L258) [[5]](diffhunk://#diff-c388f8db50ebb181ed32a5b56f51a632839580ad0855e55a6a57b449081ca37aL330) [[6]](diffhunk://#diff-c388f8db50ebb181ed32a5b56f51a632839580ad0855e55a6a57b449081ca37aL354)